### PR TITLE
feature #82: added ability to delete comments

### DIFF
--- a/fictadvisor-api/src/v2/api/controllers/DisciplineTeacherController.ts
+++ b/fictadvisor-api/src/v2/api/controllers/DisciplineTeacherController.ts
@@ -27,6 +27,8 @@ import { UpdateCommentDTO } from '../dtos/UpdateCommentDTO';
 import { UpdatedCommentResponse } from '../responses/UpdatedCommentResponse';
 import { ApiEndpoint } from '../../utils/documentation/decorators';
 import { QuestionMapper } from '../../mappers/QuestionMapper';
+import { DeleteCommentDTO } from '../dtos/DeleteCommentDTO';
+import { DeleteCommentResponse } from '../responses/DeleteCommentResponse';
 
 @ApiTags('DisciplineTeacher')
 @Controller({
@@ -306,5 +308,54 @@ export class DisciplineTeacherController {
   ) {
     const updatedComment = await this.disciplineTeacherService.updateComment(disciplineTeacherId, body);
     return this.questionMapper.getUpdatedComment(updatedComment);
+  }
+
+  @ApiBearerAuth()
+  @ApiOkResponse({
+    type: DeleteCommentResponse,
+  })
+  @ApiBadRequestResponse({
+    description: `\n
+    InvalidEntityIdException:
+      User with such id is not found
+      Question with such id is not found
+      DisciplineTeacher with such id is not found
+      
+    InvalidTypeException
+      Question has wrong type
+      
+    InvalidBodyException:
+      UserId should not be empty
+      QuestionId should not be empty`,
+  })
+  @ApiForbiddenResponse({
+    description: `
+      NoPermissionException: You do not have permission to perform this action`,
+  })
+  @ApiUnauthorizedResponse({
+    description: `\n
+    UnauthorizedException:
+      Unauthorized`,
+  })
+  @ApiForbiddenResponse({
+    description: `\n
+    NoPermissionException:
+      You do not have permission to perform this action`,
+  })
+  @ApiParam({
+    name: 'disciplineTeacherId',
+    required: true,
+    description: 'Discipline teacher id',
+  })
+  @ApiEndpoint({
+    summary: 'Delete question answers with TEXT type (comments)',
+    permissions: PERMISSION.COMMENTS_DELETE,
+  })
+  @Delete('/:disciplineTeacherId/comment')
+  async deleteComment (
+    @Param('disciplineTeacherId', DisciplineTeacherByIdPipe) disciplineTeacherId: string,
+    @Body() body: DeleteCommentDTO
+  ) {
+    return await this.disciplineTeacherService.deleteComment(disciplineTeacherId, body);
   }
 }

--- a/fictadvisor-api/src/v2/api/dtos/DeleteCommentDTO.ts
+++ b/fictadvisor-api/src/v2/api/dtos/DeleteCommentDTO.ts
@@ -1,0 +1,17 @@
+import { IsNotEmpty } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+import { validationOptionsMsg } from '../../utils/GLOBALS';
+
+export class DeleteCommentDTO {
+  @ApiProperty({
+    description: 'User\'s ID who provided the answer.',
+  })
+  @IsNotEmpty(validationOptionsMsg('UserId should not be empty'))
+    userId: string;
+
+  @ApiProperty({
+    description: 'Question id',
+  })
+  @IsNotEmpty(validationOptionsMsg('QuestionId should not be empty'))
+    questionId: string;
+}

--- a/fictadvisor-api/src/v2/api/dtos/UpdateCommentDTO.ts
+++ b/fictadvisor-api/src/v2/api/dtos/UpdateCommentDTO.ts
@@ -1,20 +1,9 @@
 import { IsNotEmpty, IsString } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 import { validationOptionsMsg } from '../../utils/GLOBALS';
+import { DeleteCommentDTO } from './DeleteCommentDTO';
 
-export class UpdateCommentDTO {
-  @ApiProperty({
-    description: 'User\'s ID who provided the answer.',
-  })
-  @IsNotEmpty(validationOptionsMsg('UserId should not be empty'))
-    userId: string;
-
-  @ApiProperty({
-    description: 'Question id',
-  })
-  @IsNotEmpty(validationOptionsMsg('QuestionId should not be empty'))
-    questionId: string;
-
+export class UpdateCommentDTO extends DeleteCommentDTO {
   @ApiProperty({
     description: 'New comment value',
   })

--- a/fictadvisor-api/src/v2/api/responses/DeleteCommentResponse.ts
+++ b/fictadvisor-api/src/v2/api/responses/DeleteCommentResponse.ts
@@ -1,0 +1,23 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class DeleteCommentResponse {
+  @ApiProperty({
+    description: 'Discipline teacher id',
+  })
+    disciplineTeacherId: string;
+
+  @ApiProperty({
+    description: 'Question id',
+  })
+    questionId: string;
+
+  @ApiProperty({
+    description: 'Id of the user who leave the comment',
+  })
+    userId: string;
+
+  @ApiProperty({
+    description: 'Value of deleted comment',
+  })
+    value: string;
+}

--- a/fictadvisor-api/src/v2/api/services/DisciplineTeacherService.ts
+++ b/fictadvisor-api/src/v2/api/services/DisciplineTeacherService.ts
@@ -26,6 +26,7 @@ import { IsRemovedDisciplineTeacherException } from '../../utils/exceptions/IsRe
 import { UpdateCommentDTO } from '../dtos/UpdateCommentDTO';
 import { QuestionRepository } from '../../database/repositories/QuestionRepository';
 import { InvalidTypeException } from '../../utils/exceptions/InvalidTypeException';
+import { DeleteCommentDTO } from '../dtos/DeleteCommentDTO';
 
 @Injectable()
 export class DisciplineTeacherService {
@@ -343,7 +344,7 @@ export class DisciplineTeacherService {
     });
   }
 
-  async validateUpdateCommentBody (body: UpdateCommentDTO) {
+  async validateCommentBody (body: UpdateCommentDTO | DeleteCommentDTO) {
     const user = await this.userRepository.findById(body.userId);
     if (!user) {
       throw new InvalidEntityIdException('User');
@@ -359,7 +360,7 @@ export class DisciplineTeacherService {
   }
 
   async updateComment (disciplineTeacherId: string, body: UpdateCommentDTO) {
-    await this.validateUpdateCommentBody(body);
+    await this.validateCommentBody(body);
     return this.questionAnswerRepository.update({
       disciplineTeacherId_questionId_userId: {
         disciplineTeacherId: disciplineTeacherId,
@@ -369,6 +370,19 @@ export class DisciplineTeacherService {
     },
     {
       value: body.comment,
+    });
+  }
+
+  async deleteComment (disciplineTeacherId: string, body: DeleteCommentDTO) {
+    await this.validateCommentBody(body);
+    return this.questionAnswerRepository.delete({
+      where: {
+        disciplineTeacherId_questionId_userId: {
+          disciplineTeacherId, 
+          questionId: body.questionId, 
+          userId: body.userId,
+        },
+      },
     });
   }
 }

--- a/fictadvisor-api/src/v2/database/repositories/QuestionAnswerRepository.ts
+++ b/fictadvisor-api/src/v2/database/repositories/QuestionAnswerRepository.ts
@@ -52,4 +52,10 @@ export class QuestionAnswerRepository {
       include: this.include,
     });
   }
+
+  delete (args: Prisma.QuestionAnswerDeleteArgs) {
+    return this.prisma.questionAnswer.delete({
+      ...args,
+    });
+  }
 }

--- a/fictadvisor-api/src/v2/security/PERMISSION.ts
+++ b/fictadvisor-api/src/v2/security/PERMISSION.ts
@@ -58,6 +58,7 @@ export enum PERMISSION {
   ROLES_$ROLEID_GRANT_UPDATE = 'roles.grant.update',
 
   COMMENTS_UPDATE = 'comments.update',
+  COMMENTS_DELETE = 'comments.delete',
 
   GRANTS_DELETE = 'grants.delete',
 


### PR DESCRIPTION
- сreated deleteComment in QuestionAnswerRepository
- сreated DELETE disciplineTeachers/:disciplineTeacherId/comment endpoint
- created DeleteCommentDTO
- created DeleteCommentResponse
- unificated validateCommentBody method at QuestionAnswerService.ts
- сreated delete method to QuestionAnswerRepository
- added permission
- added Swagger documentation

closes [#82](https://github.com/fictadvisor/fictadvisor/issues/82)