### PR TITLE
design #77: Change role names to icons on mobile teacher's page and teacher searches

### DIFF
--- a/fictadvisor-web/src/components/common/ui/cards/card-roles/CardRoles.module.scss
+++ b/fictadvisor-web/src/components/common/ui/cards/card-roles/CardRoles.module.scss
@@ -6,4 +6,7 @@
   overflow: hidden;
   gap: 4px;
   justify-content: flex-start;
+  svg {
+    width: 20px;
+  }
 }

--- a/fictadvisor-web/src/components/common/ui/cards/card-roles/CardRoles.tsx
+++ b/fictadvisor-web/src/components/common/ui/cards/card-roles/CardRoles.tsx
@@ -1,4 +1,9 @@
-import { FC } from 'react';
+import { FC, ReactNode } from 'react';
+import {
+  BeakerIcon,
+  BookOpenIcon,
+  WrenchIcon,
+} from '@heroicons/react/24/outline';
 import cn from 'classnames';
 
 import Tag from '@/components/common/ui/tag';
@@ -10,6 +15,7 @@ import styles from './CardRoles.module.scss';
 export interface CardRolesProps {
   roles: TeacherRole[];
   className?: string;
+  isDesktop?: boolean;
 }
 
 const TagText: Record<TeacherRole, string> = {
@@ -28,13 +34,29 @@ const TagColors: Record<TeacherRole, TagColor> = {
   [TeacherRole.OTHER]: TagColor.PRIMARY,
 };
 
-export const CardRoles: FC<CardRolesProps> = ({ roles, className }) => {
+const TagIcons: Record<TeacherRole, ReactNode> = {
+  [TeacherRole.LABORANT]: <BeakerIcon />,
+  [TeacherRole.LECTURER]: <BookOpenIcon />,
+  [TeacherRole.PRACTICIAN]: <WrenchIcon />,
+  [TeacherRole.EXAMINER]: null,
+  [TeacherRole.OTHER]: null,
+};
+
+export const CardRoles: FC<CardRolesProps> = ({
+  roles,
+  className,
+  isDesktop,
+}) => {
   return (
     <div className={cn(styles['card-roles'], className)}>
       {roles.map(role => (
         <Tag
+          sx={{
+            display: ['EXAMINER', 'OTHER'].includes(role) ? 'none' : 'flex',
+          }}
           size={TagSize.SMALL}
-          text={TagText[role]}
+          text={isDesktop ? TagText[role] : ''}
+          icon={isDesktop ? null : TagIcons[role]}
           color={TagColors[role]}
           key={Math.random()}
         />

--- a/fictadvisor-web/src/components/common/ui/cards/personal-teacher-card/PersonalTeacherCard.tsx
+++ b/fictadvisor-web/src/components/common/ui/cards/personal-teacher-card/PersonalTeacherCard.tsx
@@ -1,6 +1,6 @@
 import React, { FC, useContext, useEffect, useRef, useState } from 'react';
 import { ChevronDownIcon, ChevronUpIcon } from '@heroicons/react/24/outline';
-import { Box, Typography } from '@mui/material';
+import { Box, Typography, useMediaQuery } from '@mui/material';
 
 import Button from '@/components/common/ui/button-mui';
 import { ButtonVariant } from '@/components/common/ui/button-mui/types';
@@ -8,6 +8,7 @@ import { CardRoles } from '@/components/common/ui/cards/card-roles';
 import Rating from '@/components/common/ui/rating';
 import { teacherContext } from '@/components/pages/personal-teacher-page/PersonalTeacherPage';
 import { teacherSubjectContext } from '@/components/pages/personal-teacher-subject-page/PersonalTeacherSubjectPage';
+import theme from '@/styles/theme';
 import { Contact } from '@/types/contact';
 import { TeacherRole, TeacherSubject } from '@/types/teacher';
 
@@ -45,6 +46,7 @@ const PersonalTeacherCard: FC<TeacherCard> = ({
   const blockRef = useRef<HTMLDivElement>(null);
   const { setFloatingCardShowed } = useContext(teacherContext);
   const { setSubjectFloatingCardShowed } = useContext(teacherSubjectContext);
+  const isDesktop = useMediaQuery(theme.breakpoints.up('mobileMedium'));
   const contactsStatus = isContactsVisible ? 'shown' : 'hidden';
   useEffect(() => {
     const handleScroll = () => {
@@ -81,7 +83,7 @@ const PersonalTeacherCard: FC<TeacherCard> = ({
         </Box>
       )}
       <Box sx={styles.tags(isSubjectCard)}>
-        <CardRoles roles={roles} />
+        <CardRoles roles={roles} isDesktop={isDesktop} />
       </Box>
       {!isSubjectCard && (
         <Box sx={styles.info}>

--- a/fictadvisor-web/src/components/common/ui/cards/teacher-card/TeacherCard.styles.ts
+++ b/fictadvisor-web/src/components/common/ui/cards/teacher-card/TeacherCard.styles.ts
@@ -1,14 +1,9 @@
 import { SxProps, Theme } from '@mui/material/styles';
 
 export const teacherCard = (isSubject: boolean): SxProps<Theme> => ({
-  ...(isSubject && {
-    maxHeight: '132px',
-  }),
-  ...(!isSubject && {
-    height: '104px',
-  }),
+  height: '140px',
   padding: '12px',
-  backgroundColor: 'backgroundDark.300',
+  backgroundColor: 'backgroundDark.200',
   borderRadius: '6px',
   width: '100%',
   minWidth: 'fit-content',
@@ -52,10 +47,11 @@ export const teacherCardShift = (isSubject: boolean): SxProps<Theme> => ({
   display: 'flex',
   flexDirection: 'column',
   position: 'relative',
-  top: '-50px',
-  ...(!isSubject && {
-    gap: '8px',
-  }),
+  top: '-44px',
+  gap: {
+    mobileMedium: '12px',
+    mobile: '8px',
+  },
 });
 
 export const teacherCardTopPart: SxProps<Theme> = {
@@ -72,9 +68,6 @@ export const teacherCardAvatar = (isSubject: boolean): SxProps<Theme> => ({
   boxShadow: '0 0 0 2px backgroundDark.300',
   borderRadius: '100%',
   WebkitBorderRadius: '100%',
-  ...(isSubject && {
-    marginBottom: '12px',
-  }),
 });
 
 export const teacherCardTopPartRating: SxProps<Theme> = {
@@ -84,7 +77,7 @@ export const teacherCardTopPartRating: SxProps<Theme> = {
 
 export const teacherCardName = (isSubject: boolean): SxProps<Theme> => ({
   typography: {
-    desktopSemiMedium: 'body2Bold',
+    mobileMedium: 'body2Bold',
     mobile: isSubject ? 'body2Bold' : 'body1Bold',
   },
   display: '-webkit-box',
@@ -94,9 +87,6 @@ export const teacherCardName = (isSubject: boolean): SxProps<Theme> => ({
     mobile: 3,
     desktopSemiMedium: 2,
   },
-  ...(isSubject && {
-    marginTop: '12px',
-  }),
 });
 
 export const teacherCardRoles: SxProps<Theme> = {

--- a/fictadvisor-web/src/components/common/ui/cards/teacher-card/TeacherCard.tsx
+++ b/fictadvisor-web/src/components/common/ui/cards/teacher-card/TeacherCard.tsx
@@ -47,7 +47,7 @@ export const TeacherCard: React.FC<TeacherCardProps> = ({
             )}
           </Box>
         </Box>
-        {isSubjectCard && <CardRoles roles={roles} />}
+        <CardRoles roles={roles} />
         <Typography sx={styles.teacherCardName(isSubjectCard)}>
           {name}
         </Typography>

--- a/fictadvisor-web/src/components/pages/search-pages/teacher-search/components/TeacherSearchList.tsx
+++ b/fictadvisor-web/src/components/pages/search-pages/teacher-search/components/TeacherSearchList.tsx
@@ -31,6 +31,7 @@ export const TeacherSearchList: FC<TeacherSearchListProps> = ({ teachers }) => {
             key={teacher.id}
             name={`${teacher.lastName} ${teacher.firstName} ${teacher.middleName}`}
             rating={teacher.rating / 20}
+            roles={teacher.roles}
           />
         </Link>
       ))}


### PR DESCRIPTION
- changed role names to icons on survey, subject, teacher page
- changed the display of the "Інше" and "Екзамени" roles

closes #77