### PR TITLE
bug #130: fixed a bug with the toast message about unselected disciplines on the survey page

### DIFF
--- a/fictadvisor-api/src/v2/api/services/PollService.ts
+++ b/fictadvisor-api/src/v2/api/services/PollService.ts
@@ -332,7 +332,7 @@ export class PollService {
     });
 
     const hasSelective = await this.checkDoesUserHaveSelectiveDisciplines(userId, semesters[0]);
-    const hasSelectedInLastSemester = !hasSelective && (await this.getSelectedInSemester(semesters[0], userId)).length;
+    const hasSelectedInLastSemester = hasSelective && (await this.getSelectedInSemester(semesters[0], userId)).length;
 
     return {
       hasSelectedInLastSemester: !!hasSelectedInLastSemester,


### PR DESCRIPTION
- fixed a bug when /poll/teachers/:userId always returned hasSelectedInLastSemester: false

closes #130