### PR TITLE
bug #190: changed disciplineType to eventType

### DIFF
--- a/fictadvisor-api/src/v2/api/responses/DisciplineTypeResponse.ts
+++ b/fictadvisor-api/src/v2/api/responses/DisciplineTypeResponse.ts
@@ -16,14 +16,3 @@ export class DisciplineTypeResponse {
   })
     name: EventTypeEnum;
 }
-
-export class GeneralDisciplineTypeResponse {
-  @ApiProperty()
-    id: string;
-  @ApiProperty()
-    disciplineId: string;
-  @ApiProperty({
-    enum: [EventTypeEnum.LECTURE, EventTypeEnum.PRACTICE, EventTypeEnum.LABORATORY],
-  })
-    name: EventTypeEnum;
-}

--- a/fictadvisor-api/src/v2/api/responses/MainEventInfoResponse.ts
+++ b/fictadvisor-api/src/v2/api/responses/MainEventInfoResponse.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { DisciplineTypeResponse, GeneralDisciplineTypeResponse } from './DisciplineTypeResponse';
+import { EventTypeEnum } from '../dtos/EventTypeEnum';
 
 export class SimpleEventInfoResponse {
   @ApiProperty({
@@ -25,15 +25,16 @@ export class SimpleEventInfoResponse {
 
 export class MainEventInfoResponse extends SimpleEventInfoResponse {
   @ApiProperty({
-    type: DisciplineTypeResponse,
+    enum: EventTypeEnum,
     description: 'Type of event',
   })
-    eventType: DisciplineTypeResponse;
+    eventType: EventTypeEnum;
 }
 
 export class GeneralEventInfoResponse extends SimpleEventInfoResponse {
   @ApiProperty({
-    type: GeneralDisciplineTypeResponse,
+    enum: [EventTypeEnum.LECTURE, EventTypeEnum.PRACTICE, EventTypeEnum.LABORATORY],
+    description: 'General event type',
   })
-    disciplineType: GeneralDisciplineTypeResponse;
+    eventType: EventTypeEnum;
 }

--- a/fictadvisor-web/src/components/pages/schedule-page/schedule-event-edit-section/schedule-form/ScheduleEventForm.tsx
+++ b/fictadvisor-web/src/components/pages/schedule-page/schedule-event-edit-section/schedule-form/ScheduleEventForm.tsx
@@ -85,13 +85,11 @@ export const ScheduleEventForm: FC<ScheduleEventFormProps> = ({
             <Box sx={styles.content}>
               <Typography variant="body1Medium">Тип</Typography>
               <ScheduleFormikDropdown
-                name={'disciplineType'}
+                name="eventType"
                 options={eventTypeList}
                 placeholder={'Оберіть тип події'}
               />
-              {values.disciplineType && (
-                <DisciplineRelatedFields values={values} />
-              )}
+              {values.eventType && <DisciplineRelatedFields values={values} />}
               <Typography variant="body1Medium">Дата початку</Typography>
               <CalendarInput date={date} setDate={setDate} />
               {date && (
@@ -140,7 +138,7 @@ export const ScheduleEventForm: FC<ScheduleEventFormProps> = ({
                     textPosition={TabTextPosition.CENTER}
                     value={InfoCardTabs.EVENT}
                   />
-                  {values.disciplineType && (
+                  {values.eventType && (
                     <Tab
                       disableRipple
                       label="Про дисципліну"

--- a/fictadvisor-web/src/components/pages/schedule-page/schedule-event-edit-section/schedule-form/constants/index.ts
+++ b/fictadvisor-web/src/components/pages/schedule-page/schedule-event-edit-section/schedule-form/constants/index.ts
@@ -1,12 +1,12 @@
 import { DropDownOption } from '@/components/common/ui/form/dropdown/types';
 import { TagColor, TagSize } from '@/components/common/ui/tag/types';
 import { SharedEventBody } from '@/lib/api/schedule/types/shared';
-import { TDiscipline, TEventPeriod } from '@/types/schedule';
+import { TEvent, TEventPeriod } from '@/types/schedule';
 
 export const initialValues: SharedEventBody = {
   name: '',
   disciplineId: '',
-  disciplineType: '',
+  eventType: '',
   teachers: [],
   startTime: '',
   endTime: '',
@@ -18,37 +18,37 @@ export const initialValues: SharedEventBody = {
 
 export const eventTypeList: DropDownOption[] = [
   {
-    id: TDiscipline.LABORATORY,
+    id: TEvent.LABORATORY,
     text: 'Лабораторна',
     color: TagColor.MINT,
     size: TagSize.SMALL,
   },
   {
-    id: TDiscipline.EXAM,
+    id: TEvent.EXAM,
     text: 'Екзамен',
     color: TagColor.VIOLET,
     size: TagSize.SMALL,
   },
   {
-    id: TDiscipline.WORKOUT,
+    id: TEvent.WORKOUT,
     text: 'Відпрацювання',
     color: TagColor.PRIMARY,
     size: TagSize.SMALL,
   },
   {
-    id: TDiscipline.PRACTICE,
+    id: TEvent.PRACTICE,
     text: 'Практика',
     color: TagColor.ORANGE,
     size: TagSize.SMALL,
   },
   {
-    id: TDiscipline.LECTURE,
+    id: TEvent.LECTURE,
     text: 'Лекція',
     color: TagColor.INDIGO,
     size: TagSize.SMALL,
   },
   {
-    id: TDiscipline.CONSULTATION,
+    id: TEvent.CONSULTATION,
     text: 'Консультація',
     color: TagColor.SUCCESS,
     size: TagSize.SMALL,

--- a/fictadvisor-web/src/components/pages/schedule-page/schedule-event-edit-section/schedule-form/validation/index.ts
+++ b/fictadvisor-web/src/components/pages/schedule-page/schedule-event-edit-section/schedule-form/validation/index.ts
@@ -37,7 +37,7 @@ export const formValidationSchema = yup.object().shape({
   disciplineInfo: yup.string().max(2000, 'Не довше 2000 символів'),
   period: yup.string().required("Обов'язкове поле"),
   url: yup.string().url('Неправильне посилання'),
-  disciplineId: yup.string().when('disciplineType', ([type], schema) => {
+  disciplineId: yup.string().when('eventType', ([type], schema) => {
     return type ? schema.required("Обов'язкове поле") : schema.optional();
   }),
 });

--- a/fictadvisor-web/src/components/pages/schedule-page/schedule-event-edit-section/schedule-info-card/ScheduleInfoCard.tsx
+++ b/fictadvisor-web/src/components/pages/schedule-page/schedule-event-edit-section/schedule-info-card/ScheduleInfoCard.tsx
@@ -19,29 +19,29 @@ import useAuthentication from '@/hooks/use-authentication';
 import { DetailedEventBody } from '@/lib/api/schedule/types/DetailedEventBody';
 import PermissionService from '@/lib/services/permisson/PermissionService';
 import { PERMISSION, PermissionData } from '@/lib/services/permisson/types';
-import { TDiscipline } from '@/types/schedule';
+import { TEvent } from '@/types/schedule';
 
 import { skeletonProps } from '../utils/skeletonProps';
 
 import * as styles from './ScheduleInfoCard.styles';
 
 const TagLabelMapper: Record<string, string> = {
-  [TDiscipline.LECTURE]: 'Лекція',
-  [TDiscipline.EXAM]: 'Екзамен',
-  [TDiscipline.LABORATORY]: 'Лабораторна',
-  [TDiscipline.CONSULTATION]: 'Консультація',
-  [TDiscipline.PRACTICE]: 'Практика',
-  [TDiscipline.WORKOUT]: 'Відпрацювання',
+  [TEvent.LECTURE]: 'Лекція',
+  [TEvent.EXAM]: 'Екзамен',
+  [TEvent.LABORATORY]: 'Лабораторна',
+  [TEvent.CONSULTATION]: 'Консультація',
+  [TEvent.PRACTICE]: 'Практика',
+  [TEvent.WORKOUT]: 'Відпрацювання',
   ['null']: 'Інша подія',
 };
 
 const TagColorMapper: Record<string, TagColor> = {
-  [TDiscipline.LECTURE]: TagColor.INDIGO,
-  [TDiscipline.EXAM]: TagColor.VIOLET,
-  [TDiscipline.LABORATORY]: TagColor.MINT,
-  [TDiscipline.CONSULTATION]: TagColor.VIOLET,
-  [TDiscipline.PRACTICE]: TagColor.ORANGE,
-  [TDiscipline.WORKOUT]: TagColor.VIOLET,
+  [TEvent.LECTURE]: TagColor.INDIGO,
+  [TEvent.EXAM]: TagColor.VIOLET,
+  [TEvent.LABORATORY]: TagColor.MINT,
+  [TEvent.CONSULTATION]: TagColor.VIOLET,
+  [TEvent.PRACTICE]: TagColor.ORANGE,
+  [TEvent.WORKOUT]: TagColor.VIOLET,
   ['null']: TagColor.VIOLET,
 };
 
@@ -107,8 +107,8 @@ const ScheduleInfoCard: FC<ScheduleInfoCardProps> = ({
           <Skeleton {...skeletonProps} width={100} height={25} />
         ) : (
           <Tag
-            text={TagLabelMapper[event.disciplineType]}
-            color={TagColorMapper[event.disciplineType]}
+            text={TagLabelMapper[event.eventType]}
+            color={TagColorMapper[event.eventType]}
           />
         )}
         <Typography variant="body1Medium">Викладач</Typography>

--- a/fictadvisor-web/src/components/pages/schedule-page/schedule-event-edit-section/utils/prepareData.ts
+++ b/fictadvisor-web/src/components/pages/schedule-page/schedule-event-edit-section/utils/prepareData.ts
@@ -20,7 +20,7 @@ export const prepareData = (
     }
   }
 
-  if (finalData.disciplineType?.length === 0) finalData.disciplineType = null;
+  if (finalData.eventType?.length === 0) finalData.eventType = null;
 
   finalData.changeStartDate =
     new Date(initialData.startTime as string).toDateString() !==

--- a/fictadvisor-web/src/components/pages/schedule-page/schedule-section/ScheduleSectionMobile.tsx
+++ b/fictadvisor-web/src/components/pages/schedule-page/schedule-section/ScheduleSectionMobile.tsx
@@ -15,7 +15,7 @@ const ScheduleSectionMobile = () => {
     state => ({
       events: state.eventsBody,
       week: state.week,
-      disciplines: state.disciplineTypes,
+      disciplines: state.eventTypes,
       loading: state.isLoading,
       currentTime: state.currentTime,
     }),
@@ -28,11 +28,7 @@ const ScheduleSectionMobile = () => {
       JSON.stringify(events[week - 1]),
     );
     _eventsWeek.events = _eventsWeek.events.filter(event => {
-      return disciplines.some(
-        discipline =>
-          discipline === event.disciplineType ||
-          discipline === event?.disciplineType?.name,
-      );
+      return disciplines.some(discipline => discipline === event.eventType);
     });
     return _eventsWeek;
   }, [disciplines, events, week]);

--- a/fictadvisor-web/src/components/pages/schedule-page/schedule-section/components/schedule/Schedule.tsx
+++ b/fictadvisor-web/src/components/pages/schedule-page/schedule-section/components/schedule/Schedule.tsx
@@ -19,7 +19,7 @@ const Schedule = () => {
     state => ({
       events: state.eventsBody,
       week: state.week,
-      disciplines: state.disciplineTypes,
+      disciplines: state.eventTypes,
       loading: state.isLoading,
       currentTime: state.currentTime.toISOString(),
     }),
@@ -31,11 +31,7 @@ const Schedule = () => {
       JSON.stringify(events[week - 1]),
     );
     _eventsWeek.events = _eventsWeek.events.filter(event => {
-      return disciplines.some(
-        discipline =>
-          discipline === event.disciplineType ||
-          discipline === event?.disciplineType?.name,
-      );
+      return disciplines.some(discipline => discipline === event.eventType);
     });
     return _eventsWeek;
   }, [disciplines, events, week]);

--- a/fictadvisor-web/src/components/pages/schedule-page/schedule-section/components/schedule/components/schedule-column/components/schedule-card/cards/Cards.styles.ts
+++ b/fictadvisor-web/src/components/pages/schedule-page/schedule-section/components/schedule/components/schedule-column/components/schedule-card/cards/Cards.styles.ts
@@ -1,6 +1,6 @@
 import { SxProps, Theme } from '@mui/material/styles';
 
-import { TDiscipline } from '@/types/schedule';
+import { TEvent } from '@/types/schedule';
 
 const otherSubjects = (isPastEvent: boolean): SxProps<Theme> => ({
   backgroundColor: 'violet.100',
@@ -55,7 +55,7 @@ const trim4lines = {
   lineHeight: 1.3,
 };
 const subjectColors = (
-  disciplineType: TDiscipline | null,
+  eventType: TEvent | null,
   isPastEvent: boolean,
 ): SxProps<Theme> => ({
   '& .MuiTypography-body1': {
@@ -63,7 +63,7 @@ const subjectColors = (
     typography: 'body1Medium',
     ...trim4lines,
   },
-  ...(disciplineType === 'LECTURE' && {
+  ...(eventType === 'LECTURE' && {
     backgroundColor: 'indigo.100',
     borderColor: 'indigo.700',
     '& .MuiTypography-body2': {
@@ -108,7 +108,7 @@ const subjectColors = (
       },
     }),
   }),
-  ...(disciplineType === 'PRACTICE' && {
+  ...(eventType === 'PRACTICE' && {
     backgroundColor: 'orange.100',
     borderColor: 'orange.500',
     '& .MuiTypography-body2': {
@@ -152,7 +152,7 @@ const subjectColors = (
       },
     }),
   }),
-  ...(disciplineType === 'LABORATORY' && {
+  ...(eventType === 'LABORATORY' && {
     backgroundColor: 'mint.100',
     borderColor: 'mint.600',
     '& .MuiTypography-body2': {
@@ -196,9 +196,9 @@ const subjectColors = (
       },
     }),
   }),
-  ...(disciplineType !== 'LABORATORY' &&
-    disciplineType !== 'PRACTICE' &&
-    disciplineType !== 'LECTURE' && {
+  ...(eventType !== 'LABORATORY' &&
+    eventType !== 'PRACTICE' &&
+    eventType !== 'LECTURE' && {
       ...otherSubjects(isPastEvent),
     }),
 });
@@ -218,7 +218,7 @@ export const wrapper: SxProps<Theme> = {
 };
 
 export const card = (
-  disciplineType: TDiscipline | null,
+  eventType: TEvent | null,
   height: string | number,
   minHeight = 'unset',
   isPastEvent: boolean,
@@ -250,7 +250,7 @@ export const card = (
   outlineColor: { mobile: 'transparent', tablet: '#1E1E1E' },
   overflow: 'hidden',
 
-  ...subjectColors(disciplineType, isPastEvent),
+  ...subjectColors(eventType, isPastEvent),
 });
 
 export const packedCard = (

--- a/fictadvisor-web/src/components/pages/schedule-page/schedule-section/components/schedule/components/schedule-column/components/schedule-card/cards/ScheduleEvent.tsx
+++ b/fictadvisor-web/src/components/pages/schedule-page/schedule-section/components/schedule/components/schedule-column/components/schedule-card/cards/ScheduleEvent.tsx
@@ -28,12 +28,7 @@ const ScheduleEvent: FC<ScheduleEventProps> = ({
 }) => {
   return (
     <Button
-      sx={styles.card(
-        event.disciplineType ? event.disciplineType.name : null,
-        height,
-        minHeight,
-        isPastEvent,
-      )}
+      sx={styles.card(event.eventType, height, minHeight, isPastEvent)}
       disableRipple
       onClick={() => onClick(event, week)}
     >

--- a/fictadvisor-web/src/components/pages/schedule-page/schedule-section/components/schedule/components/schedule-column/components/schedule-card/cards/ScheduleEvents.tsx
+++ b/fictadvisor-web/src/components/pages/schedule-page/schedule-section/components/schedule/components/schedule-column/components/schedule-card/cards/ScheduleEvents.tsx
@@ -36,12 +36,7 @@ const ScheduleEvent: FC<ScheduleEventsProps> = ({
           <Button
             key={event.id}
             sx={mergeSx(
-              styles.card(
-                event.disciplineType ? event.disciplineType.name : null,
-                eventHeight,
-                'unset',
-                isPastEvent,
-              ),
+              styles.card(event.eventType, eventHeight, 'unset', isPastEvent),
               styles.packedCard(top, width, left),
             )}
             disableRipple

--- a/fictadvisor-web/src/lib/api/schedule/ScheduleAPI.ts
+++ b/fictadvisor-web/src/lib/api/schedule/ScheduleAPI.ts
@@ -80,7 +80,7 @@ class ScheduleAPI {
   ): Promise<DetailedEventBody> {
     const { data } = await client.post<DetailedEventBody>(
       `schedule/events`,
-      body,
+      { ...body, groupId },
       getAuthorizationHeader(),
     );
     return data;

--- a/fictadvisor-web/src/lib/api/schedule/types/DetailedEventBody.ts
+++ b/fictadvisor-web/src/lib/api/schedule/types/DetailedEventBody.ts
@@ -1,10 +1,10 @@
-import { Event, TDiscipline } from '@/types/schedule';
+import { Event, TEvent } from '@/types/schedule';
 import { TEventPeriod } from '@/types/schedule';
 
-export interface DetailedEventBody extends Omit<Event, 'disciplineType'> {
+export interface DetailedEventBody extends Omit<Event, 'eventType'> {
   url?: string;
   eventInfo?: string;
-  disciplineType: TDiscipline | string;
+  eventType: TEvent | string;
   disciplineInfo?: string;
   disciplineId: string;
   period: TEventPeriod | string;

--- a/fictadvisor-web/src/lib/api/schedule/types/PatchEventBody.ts
+++ b/fictadvisor-web/src/lib/api/schedule/types/PatchEventBody.ts
@@ -1,9 +1,9 @@
 import { SharedEventBody } from './shared';
 
 export interface PatchEventBody
-  extends Partial<Omit<SharedEventBody, 'disciplineType'>> {
+  extends Partial<Omit<SharedEventBody, 'eventType'>> {
   week: number;
   changeStartDate: boolean;
   changeEndDate: boolean;
-  disciplineType: string | null;
+  eventType: string | null;
 }

--- a/fictadvisor-web/src/store/schedule/useSchedule.ts
+++ b/fictadvisor-web/src/store/schedule/useSchedule.ts
@@ -17,7 +17,7 @@ import { getCurrentWeek } from '@/store/schedule/utils/getCurrentWeek';
 import { getFirstDayOfAWeek } from '@/store/schedule/utils/getFirstDayOfAWeek';
 import { getWeekByDate } from '@/store/schedule/utils/getWeekByDate';
 import { Group } from '@/types/group';
-import { Event, TDiscipline } from '@/types/schedule';
+import { Event, TEvent } from '@/types/schedule';
 
 import { findFirstOf5 } from './utils/findFirstOf5';
 import { setUrlParams } from './utils/setUrlParams';
@@ -48,22 +48,17 @@ const checkboxesInitialValuesNotAuth: Checkboxes = {
   isSelective: false,
 };
 
-const CheckboxesMapper: Record<string, (TDiscipline | null)[]> = {
-  addLecture: [TDiscipline.LECTURE],
-  addLaboratory: [TDiscipline.LABORATORY],
-  addPractice: [TDiscipline.PRACTICE],
-  otherEvents: [
-    TDiscipline.CONSULTATION,
-    TDiscipline.EXAM,
-    TDiscipline.WORKOUT,
-    null,
-  ],
+const CheckboxesMapper: Record<string, (TEvent | null)[]> = {
+  addLecture: [TEvent.LECTURE],
+  addLaboratory: [TEvent.LABORATORY],
+  addPractice: [TEvent.PRACTICE],
+  otherEvents: [TEvent.CONSULTATION, TEvent.EXAM, TEvent.WORKOUT, null],
 };
 
 type State = {
   checkboxes: Checkboxes;
   semester?: GetCurrentSemester;
-  disciplineTypes: (TDiscipline | null)[];
+  eventTypes: (TEvent | null)[];
   week: number;
   groupId: string;
   eventsBody: GetEventBody[];
@@ -99,13 +94,13 @@ export const useSchedule = create<State & Action>((set, get) => {
     isLoading: false,
     currentTime: dayjs().tz(),
     isNewEventAdded: false,
-    disciplineTypes: [
-      TDiscipline.LECTURE,
-      TDiscipline.PRACTICE,
-      TDiscipline.LABORATORY,
-      TDiscipline.EXAM,
-      TDiscipline.CONSULTATION,
-      TDiscipline.WORKOUT,
+    eventTypes: [
+      TEvent.LECTURE,
+      TEvent.PRACTICE,
+      TEvent.LABORATORY,
+      TEvent.EXAM,
+      TEvent.CONSULTATION,
+      TEvent.WORKOUT,
       null,
     ],
     week: 1,
@@ -182,10 +177,10 @@ export const useSchedule = create<State & Action>((set, get) => {
     },
 
     updateCheckboxes(checkboxes) {
-      const _disciplineTypes: (TDiscipline | null)[] = [];
+      const _eventTypes: (TEvent | null)[] = [];
       for (const [key, value] of Object.entries(checkboxes)) {
         if (value && key !== 'isSelective') {
-          _disciplineTypes.push(...CheckboxesMapper[key]);
+          _eventTypes.push(...CheckboxesMapper[key]);
         }
       }
 
@@ -194,7 +189,7 @@ export const useSchedule = create<State & Action>((set, get) => {
 
       set(_ => ({
         checkboxes,
-        disciplineTypes: _disciplineTypes,
+        eventTypes: _eventTypes,
       }));
 
       if (selectiveChanged) {

--- a/fictadvisor-web/src/types/schedule.ts
+++ b/fictadvisor-web/src/types/schedule.ts
@@ -1,4 +1,4 @@
-export enum TDiscipline {
+export enum TEvent {
   LECTURE = 'LECTURE',
   PRACTICE = 'PRACTICE',
   LABORATORY = 'LABORATORY',
@@ -12,11 +12,7 @@ export interface Event {
   name: string;
   startTime: string;
   endTime: string;
-  disciplineType: {
-    id: string;
-    disciplineId: string;
-    name: TDiscipline;
-  } | null;
+  eventType: TEvent | null;
 }
 
 export enum TEventPeriod {


### PR DESCRIPTION
frontend
- changed all the places where disciplineType.name is used to eventType
- changed all appearances of disciplineType to eventType
- changed manually written types used in `generics` for ScheduleApi to types from backend

backend
- changed response fields from disciplineType to eventType on /schedule/groups/{groupId}/*

closes #190