### PR TITLE
feature #154: implemented creating events of type Other through bot

### DIFF
--- a/fictadvisor-api/src/v2/api/dtos/CreateEventDTO.ts
+++ b/fictadvisor-api/src/v2/api/dtos/CreateEventDTO.ts
@@ -6,63 +6,83 @@ import { EventTypeEnum } from './EventTypeEnum';
 import { Type } from 'class-transformer';
 
 export class CreateEventDTO {
-  @ApiProperty()
+  @ApiProperty({
+    description: 'Id of a group',
+  })
   @IsUUID()
   @IsNotEmpty(validationOptionsMsg('Group id cannot be empty'))
     groupId: string;
 
-  @ApiProperty()
+  @ApiProperty({
+    description: 'Name of the event',
+  })
   @MinLength(2, validationOptionsMsg('Name is too short (min: 2)'))
   @MaxLength(150, validationOptionsMsg('Name is too long (max: 150)'))
   @IsNotEmpty(validationOptionsMsg('Name cannot be empty'))
     name: string;
 
-  @ApiPropertyOptional()
+  @ApiPropertyOptional({
+    description: 'Id of a discipline',
+  })
   @IsOptional()
     disciplineId?: string;
 
   @ApiPropertyOptional({
+    description: 'Event\'s type',
     enum: EventTypeEnum,
   })
   @IsOptional()
   @IsEnum(EventTypeEnum, validationOptionsMsg('Event type must be an enum'))
     eventType?: EventTypeEnum;
 
-  @ApiPropertyOptional()
+  @ApiPropertyOptional({
+    description: 'List of teachers',
+  })
   @IsArray(validationOptionsMsg('Teachers must be Array'))
   @IsNotEmpty(validationOptionsMsg('Teachers cannot be empty (empty array is required)'))
     teachers: string[];
 
-  @ApiProperty()
+  @ApiProperty({
+    description: 'Start time of the event',
+  })
   @IsNotEmpty(validationOptionsMsg('Start time cannot be empty'))
   @Type(() => Date)
   @IsDate(validationOptionsMsg('Start time must be Date'))
     startTime: Date;
 
-  @ApiProperty()
+  @ApiProperty({
+    description: 'End time of the event',
+  })
   @IsNotEmpty(validationOptionsMsg('End time cannot be empty'))
   @Type(() => Date)
   @IsDate(validationOptionsMsg('End time must be Date'))
     endTime: Date;
 
   @ApiProperty({
+    description: 'Event\'s period',
     enum: Period,
   })
   @IsNotEmpty(validationOptionsMsg('Period cannot be empty'))
   @IsEnum(Period, validationOptionsMsg('Period must be an enum'))
     period: Period;
 
-  @ApiPropertyOptional()
+  @ApiPropertyOptional({
+    description: 'Attached link to the event',
+  })
   @IsOptional()
   @IsUrl(undefined, validationOptionsMsg('Url must be a URL address'))
     url?: string;
 
-  @ApiPropertyOptional()
+  @ApiPropertyOptional({
+    description: 'Description of the discipline',
+  })
   @MaxLength(2000, validationOptionsMsg('Discipline description is too long (max: 2000)'))
   @IsOptional()
     disciplineInfo?: string;
 
-  @ApiPropertyOptional()
+  @ApiPropertyOptional({
+    description: 'Description of the event',
+  })
   @MaxLength(2000, validationOptionsMsg('Event description is too long (max: 2000)'))
   @IsOptional()
     eventInfo?: string;

--- a/fictadvisor-api/src/v2/api/pipes/EventByIdPipe.ts
+++ b/fictadvisor-api/src/v2/api/pipes/EventByIdPipe.ts
@@ -10,7 +10,7 @@ export class EventByIdPipe implements PipeTransform<string, Promise<string>> {
   async transform (eventId: string) {
     const event = await this.eventRepository.findById(eventId);
     if (!event) {
-      throw new InvalidEntityIdException('event');
+      throw new InvalidEntityIdException('Event');
     }
     return eventId;
   }

--- a/fictadvisor-api/src/v2/api/pipes/EventPipe.ts
+++ b/fictadvisor-api/src/v2/api/pipes/EventPipe.ts
@@ -16,7 +16,7 @@ export class EventPipe implements PipeTransform<UpdateEventDTO, Promise<UpdateEv
     if (body.disciplineId) {
       const discipline = await this.disciplineRepository.findById(body.disciplineId);
       if (!discipline) {
-        throw new InvalidEntityIdException('discipline');
+        throw new InvalidEntityIdException('Discipline');
       }
     }
 
@@ -31,7 +31,7 @@ export class EventPipe implements PipeTransform<UpdateEventDTO, Promise<UpdateEv
   private async teacherByIdPipe (teacherId: string) {
     const teacher = await this.teacherRepository.findById(teacherId);
     if (!teacher) {
-      throw new InvalidEntityIdException('teacher');
+      throw new InvalidEntityIdException('Teacher');
     }
   }
 }

--- a/fictadvisor-api/src/v2/api/responses/EventsResponse.ts
+++ b/fictadvisor-api/src/v2/api/responses/EventsResponse.ts
@@ -4,31 +4,39 @@ import { TelegramEventInfoResponse } from './TelegramGeneralEventInfoResponse';
 
 export class EventsResponse {
   @ApiProperty({
+    description: 'Week number',
     minimum: 1,
   })
     week: number;
 
   @ApiProperty({
+    description: 'List of events',
     type: [MainEventInfoResponse],
   })
     events: MainEventInfoResponse[];
 
-  @ApiProperty()
+  @ApiProperty({
+    description: 'Start time of the event',
+  })
     startTime: Date;
 }
 
 export class GeneralEventsResponse {
   @ApiProperty({
+    description: 'Week number',
     minimum: 1,
   })
     week: number;
 
   @ApiProperty({
+    description: 'List of events',
     type: [GeneralEventInfoResponse],
   })
     events: GeneralEventInfoResponse[];
 
-  @ApiProperty()
+  @ApiProperty({
+    description: 'Start time of the event',
+  })
     startTime: Date;
 }
 

--- a/fictadvisor-api/src/v2/security/multiple-access-guard/MultipleAccessGuard.ts
+++ b/fictadvisor-api/src/v2/security/multiple-access-guard/MultipleAccessGuard.ts
@@ -1,0 +1,29 @@
+import { CanActivate, ExecutionContext, Injectable, UnauthorizedException } from "@nestjs/common";
+import { ModuleRef, Reflector } from "@nestjs/core";
+
+@Injectable()
+export class MultipleAccessGuard implements CanActivate {
+  constructor (
+    private reflector: Reflector,
+    private moduleRef: ModuleRef,
+  ) {}
+
+  async canActivate (context: ExecutionContext) {
+    const accessGuards = this.reflector.get('multipleAccesses', context.getHandler());
+    const guards = accessGuards.map((guard) => this.moduleRef.get(guard));
+
+    for (let i = 0; i < guards.length; i++) {
+      let status;
+      
+      try {
+        status = await guards[i].canActivate(context);
+      } catch (error) {
+        status = false;
+      }
+
+      if (status) return true;
+    }
+
+    throw new UnauthorizedException();
+  }
+}

--- a/fictadvisor-api/src/v2/security/multiple-access-guard/MultipleAccesses.ts
+++ b/fictadvisor-api/src/v2/security/multiple-access-guard/MultipleAccesses.ts
@@ -1,0 +1,4 @@
+import { SetMetadata } from "@nestjs/common";
+
+export const MultipleAccesses = (...guards: any | any[]) =>
+  SetMetadata('multipleAccesses', typeof guards === 'function' ? [guards] : guards);

--- a/fictadvisor-api/src/v2/security/permission-guard/PermissionGuard.ts
+++ b/fictadvisor-api/src/v2/security/permission-guard/PermissionGuard.ts
@@ -22,6 +22,10 @@ export class PermissionGuard implements CanActivate {
     const permissions = this.getPermissions(context);
 
     for (const permission of permissions) {
+      if (user == null) {
+        return true;
+      }
+
       const hasPermission = await this.permissionService.hasPermission(user.id, permission);
       if (hasPermission) return true;
     }

--- a/fictadvisor-api/src/v2/utils/date/DateService.ts
+++ b/fictadvisor-api/src/v2/utils/date/DateService.ts
@@ -149,6 +149,20 @@ export class DateService {
     return { startOfWeek, endOfWeek };
   }
 
+  async getDatesOfMonth () {
+    const currentDate = new Date();
+    const startOfMonth = new Date(currentDate.getFullYear(), currentDate.getMonth(), 1);
+    const endOfMonth = new Date(currentDate.getFullYear(), currentDate.getMonth() + 1, 1, 0, 0, 0, -1);
+    return { startOfMonth, endOfMonth };
+  }
+
+  async getWeekByDate (date) {
+    const { startDate } = await this.getCurrentSemester();
+    const difference = date.getTime() - startDate.getTime();
+    const week = Math.ceil(difference / WEEK);
+    return week;
+  }
+
   async isPreviousSemesterToCurrent (semester: number, year: number) {
     const curSemester = await this.getCurrentSemester();
 


### PR DESCRIPTION
- Made createEvent, getGroupEvents, deleteEvent and update endpoints accesible from Telegram bot
- Added getGroupEventsByMonth endpoint
- Added query parameter to filter events by type from getFortnightEvents, getGroupEventsByWeek and getGroupEventsByMonth endpoints
- Removed createSimpleTelegramEvent endpoint

closes #154
