### PR TITLE
migration #116: replaced disciplineTeacherRole usage with disciplineType:

### DIFF
--- a/fictadvisor-api/prisma/migrations/20240723130307_replace_discipline_teacher_roles/migration.sql
+++ b/fictadvisor-api/prisma/migrations/20240723130307_replace_discipline_teacher_roles/migration.sql
@@ -1,0 +1,34 @@
+/*
+  Warnings:
+
+  - The primary key for the `discipline_teacher_roles` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - You are about to drop the column `role` on the `discipline_teacher_roles` table. All the data in the column will be lost.
+  - The primary key for the `question_roles` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - Changed the type of `role` on the `question_roles` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+  - Made the column `created_at` on table `question_roles` required. This step will fail if there are existing NULL values in that column.
+  - Made the column `updated_at` on table `question_roles` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- AlterTable
+ALTER TABLE "discipline_teacher_roles"
+    DROP CONSTRAINT "discipline_teacher_roles_pkey",
+    DROP COLUMN "role",
+    ADD CONSTRAINT "discipline_teacher_roles_pkey" PRIMARY KEY ("discipline_teacher_id", "discipline_type_id");
+
+-- AlterTable
+ALTER TABLE "question_roles"
+    ALTER COLUMN "created_at" SET NOT NULL,
+    ALTER COLUMN "updated_at" SET NOT NULL,
+    ALTER COLUMN "role" TYPE text;
+
+UPDATE "question_roles"
+SET "role" = CASE
+                 WHEN "role" = 'LECTURER' THEN 'LECTURE'
+                 WHEN "role" = 'PRACTICIAN' THEN 'PRACTICE'
+                 WHEN "role" = 'LABORANT' THEN 'LABORATORY'
+                 WHEN "role" = 'EXAMINER' THEN 'EXAM'
+                 ELSE 'LECTURE'
+    END;
+
+ALTER TABLE "question_roles"
+    ALTER COLUMN "role" TYPE "DisciplineTypeEnum" USING "role"::"DisciplineTypeEnum"

--- a/fictadvisor-api/prisma/schema.prisma
+++ b/fictadvisor-api/prisma/schema.prisma
@@ -2,7 +2,7 @@
 // learn more about it in the docs: https://pris.ly/d/prisma-schema
 
 generator client {
-  provider = "prisma-client-js"
+  provider      = "prisma-client-js"
   binaryTargets = ["native", "rhel-openssl-3.0.x"]
 }
 
@@ -294,13 +294,13 @@ model Question {
 }
 
 model QuestionRole {
-  role       TeacherRole
-  question   Question    @relation(fields: [questionId], references: [id], onDelete: Cascade)
-  questionId String      @map("question_id")
-  isShown    Boolean     @map("is_shown")
-  isRequired Boolean     @map("is_required")
-  createdAt  DateTime?   @default(now()) @map("created_at")
-  updatedAt  DateTime?   @default(now()) @updatedAt @map("updated_at")
+  role       DisciplineTypeEnum
+  question   Question           @relation(fields: [questionId], references: [id], onDelete: Cascade)
+  questionId String             @map("question_id")
+  isShown    Boolean            @map("is_shown")
+  isRequired Boolean            @map("is_required")
+  createdAt  DateTime           @default(now()) @map("created_at")
+  updatedAt  DateTime           @default(now()) @updatedAt @map("updated_at")
 
   @@id([questionId, role])
   @@map("question_roles")
@@ -406,11 +406,10 @@ model DisciplineTeacherRole {
   disciplineTeacherId String            @map("discipline_teacher_id")
   disciplineType      DisciplineType    @relation(fields: [disciplineTypeId], references: [id], onDelete: Cascade)
   disciplineTypeId    String            @map("discipline_type_id")
-  role                TeacherRole
   createdAt           DateTime?         @default(now()) @map("created_at")
   updatedAt           DateTime?         @default(now()) @updatedAt @map("updated_at")
 
-  @@id([disciplineTeacherId, disciplineTypeId, role])
+  @@id([disciplineTeacherId, disciplineTypeId])
   @@map("discipline_teacher_roles")
 }
 

--- a/fictadvisor-api/src/v2/api/controllers/DisciplineTeacherController.ts
+++ b/fictadvisor-api/src/v2/api/controllers/DisciplineTeacherController.ts
@@ -3,6 +3,7 @@ import {
   ApiBadRequestResponse,
   ApiBearerAuth,
   ApiBody,
+  ApiCreatedResponse,
   ApiForbiddenResponse,
   ApiOkResponse,
   ApiParam,
@@ -227,27 +228,31 @@ export class DisciplineTeacherController {
   }
 
   @ApiBearerAuth()
-  @ApiOkResponse({
+  @ApiCreatedResponse({
     type: DisciplineTeacherCreateResponse,
   })
   @ApiForbiddenResponse({
     description: `
-      NoPermissionException: You do not have permission to perform this action
+    NoPermissionException:
+      You do not have permission to perform this action
     `,
   })
   @ApiBadRequestResponse({
     description: `
-      InvalidEntityIdException: discipline with such id is not found\n
-      InvalidEntityIdException: teacher with such id is not found\n
-      InvalidBodyException: each value in roles must be one of the following values: LECTURER, LABORANT, PRACTICIAN\n
-      InvalidBodyException: roles must be an array\n
-      InvalidBodyException: roles should not be empty
-    `,
+    InvalidEntityIdException:
+      discipline with such id is not found
+      teacher with such id is not found
+      each value in roles must be one of the following values: LECTURER, LABORANT, PRACTICIAN
+      roles must be an array
+      roles should not be empty`,
   })
   @ApiBody({
     type: CreateDisciplineTeacherDTO,
   })
-  @Access(PERMISSION.DISCIPLINE_TEACHERS_CREATE)
+  @ApiEndpoint({
+    summary: 'Create disciplineTeacher with roles',
+    permissions: PERMISSION.DISCIPLINE_TEACHERS_CREATE,
+  })
   @Post()
   create (
     @Body('teacherId', TeacherByIdPipe) teacherId: string,
@@ -263,18 +268,21 @@ export class DisciplineTeacherController {
   })
   @ApiForbiddenResponse({
     description: `
-      NoPermissionException: You do not have permission to perform this action
-    `,
+    NoPermissionException:
+      You do not have permission to perform this action`,
   })
   @ApiBadRequestResponse({
     description: `
-      InvalidEntityIdException: disciplineTeacher with such id is not found\n
-      InvalidBodyException: each value in roles must be one of the following values: LECTURER, LABORANT, PRACTICIAN\n
-      InvalidBodyException: roles must be an array\n
-      InvalidBodyException: roles should not be empty
-    `,
+    InvalidEntityIdException:
+      disciplineTeacher with such id is not found
+      each value in roles must be one of the following values: LECTURER, LABORANT, PRACTICIAN
+      roles must be an array
+      roles should not be empty`,
   })
-  @Access(PERMISSION.DISCIPLINE_TEACHERS_UPDATE)
+  @ApiEndpoint({
+    summary: 'Update disciplineTeacher with its id',
+    permissions: PERMISSION.DISCIPLINE_TEACHERS_UPDATE,
+  })
   @Patch('/:disciplineTeacherId')
   updateById (
     @Param('disciplineTeacherId', DisciplineTeacherByIdPipe) disciplineTeacherId: string,
@@ -289,19 +297,22 @@ export class DisciplineTeacherController {
   })
   @ApiForbiddenResponse({
     description: `
-      NoPermissionException: You do not have permission to perform this action
-    `,
+    NoPermissionException:
+      You do not have permission to perform this action`,
   })
   @ApiBadRequestResponse({
     description: `
-      InvalidEntityIdException: discipline with such id is not found\n
-      InvalidEntityIdException: teacher with such id is not found\n
-      InvalidBodyException: each value in roles must be one of the following values: LECTURER, LABORANT, PRACTICIAN\n
-      InvalidBodyException: roles must be an array\n
-      InvalidBodyException: roles should not be empty
-    `,
+    InvalidEntityIdException: 
+      discipline with such id is not found
+      teacher with such id is not found
+      each value in roles must be one of the following values: LECTURER, LABORANT, PRACTICIAN
+      roles must be an array
+      roles should not be empty`,
   })
-  @Access(PERMISSION.DISCIPLINE_TEACHERS_UPDATE)
+  @ApiEndpoint({
+    summary: 'Update disciplineTeacher with teacherId and disciplineId',
+    permissions: PERMISSION.DISCIPLINE_TEACHERS_UPDATE,
+  })
   @Patch()
   updateByTeacherAndDiscipline (
     @Query('teacherId', TeacherByIdPipe) teacherId : string,

--- a/fictadvisor-api/src/v2/api/controllers/PollController.ts
+++ b/fictadvisor-api/src/v2/api/controllers/PollController.ts
@@ -29,7 +29,7 @@ import { QuestionByRoleAndIdPipe } from '../pipes/QuestionByRoleAndIdPipe';
 import { UserByIdPipe } from '../pipes/UserByIdPipe';
 import { QuestionMapper } from '../../mappers/QuestionMapper';
 import { PollService } from '../services/PollService';
-import { TeacherRole } from '@prisma/client';
+import { TeacherRole } from '@fictadvisor/utils/enums';
 
 @ApiTags('Poll')
 @Controller({

--- a/fictadvisor-api/src/v2/api/datas/CreateDisciplineTeacherRoleData.ts
+++ b/fictadvisor-api/src/v2/api/datas/CreateDisciplineTeacherRoleData.ts
@@ -1,7 +1,4 @@
-import { TeacherRole } from '@prisma/client';
-
 export interface CreateDisciplineTeacherRoleData {
-  role: TeacherRole,
   disciplineTeacherId: string,
   disciplineTypeId: string,
 }

--- a/fictadvisor-api/src/v2/api/pipes/QuestionByRoleAndIdPipe.ts
+++ b/fictadvisor-api/src/v2/api/pipes/QuestionByRoleAndIdPipe.ts
@@ -1,7 +1,8 @@
 import { Injectable, PipeTransform } from '@nestjs/common';
 import { QuestionRepository } from '../../database/repositories/QuestionRepository';
 import { InvalidEntityIdException } from '../../utils/exceptions/InvalidEntityIdException';
-import { TeacherRole } from '@prisma/client';
+import { TeacherRole } from '@fictadvisor/utils/enums';
+import { TeacherTypeAdapter } from '../../mappers/TeacherRoleAdapter';
 
 @Injectable()
 export class QuestionByRoleAndIdPipe implements PipeTransform {
@@ -15,7 +16,7 @@ export class QuestionByRoleAndIdPipe implements PipeTransform {
     if (!question) {
       throw new InvalidEntityIdException('question');
     }
-    if (!question.questionRoles.some((r) => r.role === role)) {
+    if (!question.questionRoles.some((questionRole) => questionRole.role === TeacherTypeAdapter[role])) {
       throw new InvalidEntityIdException('questionRole');
     }
     return params;

--- a/fictadvisor-api/src/v2/api/services/DisciplineService.ts
+++ b/fictadvisor-api/src/v2/api/services/DisciplineService.ts
@@ -12,7 +12,7 @@ import { DatabaseUtils } from '../../database/DatabaseUtils';
 import { DbDiscipline } from '../../database/entities/DbDiscipline';
 import { PaginatedData } from '../datas/PaginatedData';
 import { DisciplineTypeEnum } from '@prisma/client';
-import { TeacherRoleAdapter, TeacherTypeAdapter } from '../../mappers/TeacherRoleAdapter';
+import { TeacherTypeAdapter } from '../../mappers/TeacherRoleAdapter';
 
 @Injectable()
 export class DisciplineService {
@@ -55,11 +55,7 @@ export class DisciplineService {
 
   async create (body: CreateDisciplineDTO) {
     const { teachers, ...data } = body;
-
-    const roleNames = [];
-    teachers.forEach((t) => {
-      roleNames.push(...t.roleNames);
-    });
+    const roleNames = teachers.flatMap((teacher) => teacher.roleNames);
 
     const disciplineTypes = roleNames.map((roleName) => ({
       name: TeacherTypeAdapter[roleName],
@@ -116,12 +112,13 @@ export class DisciplineService {
   }
 
   async getTeachers (disciplineId: string, disciplineType: DisciplineTypeEnum) {
-    const role = TeacherRoleAdapter[disciplineType];
     const disciplineTeachers = await this.disciplineTeacherRepository.findMany({
       where: {
         roles: {
           some: {
-            role,
+            disciplineType: {
+              name: disciplineType,
+            },
           },
         },
         discipline: {

--- a/fictadvisor-api/src/v2/api/services/DisciplineTeacherService.ispec.ts
+++ b/fictadvisor-api/src/v2/api/services/DisciplineTeacherService.ispec.ts
@@ -15,7 +15,8 @@ import { AlreadyAnsweredException } from '../../utils/exceptions/AlreadyAnswered
 import { WrongTimeException } from '../../utils/exceptions/WrongTimeException';
 import { NoPermissionException } from '../../utils/exceptions/NoPermissionException';
 import { IsRemovedDisciplineTeacherException } from '../../utils/exceptions/IsRemovedDisciplineTeacherException';
-import { Discipline, QuestionType, State, TeacherRole } from '@prisma/client';
+import { Discipline, QuestionType, State } from '@prisma/client';
+import { DisciplineTypeEnum } from '@fictadvisor/utils';
 
 describe('DisciplineTeacherService', () => {
   let disciplineTeacherService: DisciplineTeacherService;
@@ -130,7 +131,7 @@ describe('DisciplineTeacherService', () => {
           semester: 1,
           year: 2022,
           isSelective: true,
-        }, 
+        },
         selective20222,
       ],
     });
@@ -221,15 +222,12 @@ describe('DisciplineTeacherService', () => {
       data: [{
         disciplineTeacherId: 'lecturerForNonSelective20221Id',
         disciplineTypeId: 'ec7866e2-a426-4e1b-b76c-1ce68fdb46a1',
-        role: 'LECTURER',
       }, {
         disciplineTeacherId: 'removedId1',
         disciplineTypeId: 'ec7866e2-a426-4e1b-b76c-1ce68fdb46a1',
-        role: 'LECTURER',
       }, {
         disciplineTeacherId: 'lecturerForNonSelective20222Id',
         disciplineTypeId: 'f3717ce9-cd52-4c40-889a-094a9b6a01de',
-        role: 'LECTURER',
       }],
     });
 
@@ -277,25 +275,25 @@ describe('DisciplineTeacherService', () => {
     await prismaService.questionRole.createMany({
       data: [
         {
-          role: TeacherRole.LECTURER,
+          role: DisciplineTypeEnum.LECTURE,
           questionId: 'lecturerQuestionId1',
           isShown: true,
           isRequired: true,
         },
         {
-          role: TeacherRole.LECTURER,
+          role: DisciplineTypeEnum.LECTURE,
           questionId: 'lecturerQuestionId2',
           isShown: true,
           isRequired: true,
         },
         {
-          role: TeacherRole.PRACTICIAN,
+          role: DisciplineTypeEnum.PRACTICE,
           questionId: 'practicianQuestionId',
           isShown: true,
           isRequired: false,
         },
         {
-          role: TeacherRole.LECTURER,
+          role: DisciplineTypeEnum.LECTURE,
           questionId: 'lecturerQuestionId3',
           isShown: true,
           isRequired: false,

--- a/fictadvisor-api/src/v2/api/services/PollService.ispec.ts
+++ b/fictadvisor-api/src/v2/api/services/PollService.ispec.ts
@@ -1,5 +1,5 @@
 import { Test } from '@nestjs/testing';
-import { CommentsSortOrder } from '@fictadvisor/utils/enums';
+import { CommentsSortOrder, DisciplineTypeEnum, TeacherRole } from '@fictadvisor/utils/enums';
 import { DateModule } from '../../utils/date/DateModule';
 import { MapperModule } from '../../modules/MapperModule';
 import { PrismaModule } from '../../modules/PrismaModule';
@@ -7,7 +7,7 @@ import { PollService } from './PollService';
 import { DbDiscipline } from 'src/v2/database/entities/DbDiscipline';
 import { DbQuestionWithRoles } from 'src/v2/database/entities/DbQuestionWithRoles';
 import { DbQuestionWithAnswers } from 'src/v2/database/entities/DbQuestionWithAnswers';
-import { Group, PrismaClient, QuestionDisplay, QuestionType, State, Subject, Teacher, TeacherRole, User } from '@prisma/client';
+import { Group, PrismaClient, QuestionDisplay, QuestionType, State, Subject, Teacher, User } from '@prisma/client';
 
 
 describe('PollService', () => {
@@ -212,9 +212,9 @@ describe('PollService', () => {
         order: 1,
         questionRoles: {
           createMany: { data: [
-            { role: TeacherRole.LABORANT, isRequired: false, isShown: false },
-            { role: TeacherRole.LECTURER, isRequired: true, isShown: false },
-            { role: TeacherRole.PRACTICIAN, isRequired: true, isShown: true },
+            { role: DisciplineTypeEnum.LABORATORY, isRequired: false, isShown: false },
+            { role: DisciplineTypeEnum.LECTURE, isRequired: true, isShown: false },
+            { role: DisciplineTypeEnum.PRACTICE, isRequired: true, isShown: true },
           ] },
         },
         questionAnswers: {
@@ -249,9 +249,9 @@ describe('PollService', () => {
         order: 2,
         questionRoles: {
           createMany: { data: [
-            { role: TeacherRole.LABORANT, isRequired: true, isShown: true },
-            { role: TeacherRole.LECTURER, isRequired: true, isShown: true },
-            { role: TeacherRole.PRACTICIAN, isRequired: true, isShown: true },
+            { role: DisciplineTypeEnum.LABORATORY, isRequired: true, isShown: true },
+            { role: DisciplineTypeEnum.LECTURE, isRequired: true, isShown: true },
+            { role: DisciplineTypeEnum.PRACTICE, isRequired: true, isShown: true },
           ] },
         },
         questionAnswers: {
@@ -287,9 +287,9 @@ describe('PollService', () => {
         order: 4,
         questionRoles: { createMany: {
           data: [
-            { role: TeacherRole.LABORANT, isRequired: false, isShown: true },
-            { role: TeacherRole.LECTURER, isRequired: false, isShown: true },
-            { role: TeacherRole.PRACTICIAN, isRequired: false, isShown: true },
+            { role: DisciplineTypeEnum.LABORATORY, isRequired: false, isShown: true },
+            { role: DisciplineTypeEnum.LECTURE, isRequired: false, isShown: true },
+            { role: DisciplineTypeEnum.PRACTICE, isRequired: false, isShown: true },
           ],
         } },
         questionAnswers: { createMany: {
@@ -370,13 +370,13 @@ describe('PollService', () => {
   describe('getQuestions', () => {
     it('should return all questions because it requires any teacher role and each discipline role', async () => {
       const questions = await pollService.getQuestions([
-        TeacherRole.LECTURER,
-        TeacherRole.LABORANT,
-        TeacherRole.PRACTICIAN,
+        DisciplineTypeEnum.LECTURE,
+        DisciplineTypeEnum.LABORATORY,
+        DisciplineTypeEnum.PRACTICE,
       ], [
-        TeacherRole.LECTURER,
-        TeacherRole.LABORANT,
-        TeacherRole.PRACTICIAN,
+        DisciplineTypeEnum.LECTURE,
+        DisciplineTypeEnum.LABORATORY,
+        DisciplineTypeEnum.PRACTICE,
       ]);
       expect(questions.length).toBe(3);
       expect(questions[0].questionRoles).toStrictEqual(questionMark1.questionRoles);
@@ -392,10 +392,10 @@ describe('PollService', () => {
     it('should return 2 questions: first one requires PRACTICIAN and LECTURER and show PRACTICIAN and the second one shows every role',
       async () => {
         const questions = await pollService.getQuestions([
-          TeacherRole.PRACTICIAN,
+          DisciplineTypeEnum.PRACTICE,
         ], [
-          TeacherRole.LECTURER,
-          TeacherRole.PRACTICIAN,
+          DisciplineTypeEnum.LECTURE,
+          DisciplineTypeEnum.PRACTICE,
         ]);
         expect(questions.length).toBe(2);
         expect(questions[0].questionRoles).toStrictEqual(questionMark1.questionRoles);
@@ -406,10 +406,10 @@ describe('PollService', () => {
     it('should return only one question because the second one doesn\'t show LECTURER question but only PRACTICIAN',
       async () => {
         const questions = await pollService.getQuestions([
-          TeacherRole.LECTURER,
+          DisciplineTypeEnum.LECTURE,
         ], [
-          TeacherRole.LECTURER,
-          TeacherRole.PRACTICIAN,
+          DisciplineTypeEnum.LECTURE,
+          DisciplineTypeEnum.PRACTICE,
         ]);
         expect(questions.length).toBe(1);
         expect(questions[0].questionRoles).toStrictEqual(questionText.questionRoles);

--- a/fictadvisor-api/src/v2/api/services/PollService.ts
+++ b/fictadvisor-api/src/v2/api/services/PollService.ts
@@ -9,7 +9,7 @@ import {
   SortDTO,
 } from '@fictadvisor/utils/requests';
 import { PollDisciplineTeachersResponse } from '@fictadvisor/utils/responses';
-import { CommentsSortOrder } from '@fictadvisor/utils/enums';
+import { CommentsSortOrder, DisciplineTypeEnum, TeacherRole } from '@fictadvisor/utils/enums';
 import {
   SortQATParam,
   OrderQAParam,
@@ -30,9 +30,9 @@ import { GroupRepository } from '../../database/repositories/GroupRepository';
 import {
   QuestionType,
   SemesterDate,
-  TeacherRole,
   Prisma,
 } from '@prisma/client';
+import { TeacherTypeAdapter } from '../../mappers/TeacherRoleAdapter';
 
 @Injectable()
 export class PollService {
@@ -95,7 +95,7 @@ export class PollService {
     return this.questionRepository.updateById(id, data);
   }
 
-  async getQuestions (roles: TeacherRole[], disciplineRoles: TeacherRole[]) {
+  async getQuestions (roles: DisciplineTypeEnum[], disciplineRoles: DisciplineTypeEnum[]) {
     return this.questionRepository.findMany({
       where: {
         questionRoles: {
@@ -220,6 +220,7 @@ export class PollService {
       questionRoles: {
         create: {
           ...data,
+          role: TeacherTypeAdapter[data.role],
         },
       },
     });
@@ -231,7 +232,7 @@ export class PollService {
         delete: {
           questionId_role: {
             questionId: questionId,
-            role: role,
+            role: TeacherTypeAdapter[role],
           },
         },
       },
@@ -295,7 +296,9 @@ export class PollService {
       roles?.length > 0
         ? {
           roles: {
-            some: DatabaseUtils.getSearchByArray(roles, 'role'),
+            some: {
+              disciplineType: DatabaseUtils.getSearchByArray(roles.map((role) => TeacherTypeAdapter[role]), 'name'),
+            },
           },
         }
         : {};

--- a/fictadvisor-api/src/v2/api/services/ScheduleService.ispec.ts
+++ b/fictadvisor-api/src/v2/api/services/ScheduleService.ispec.ts
@@ -835,8 +835,14 @@ describe('ScheduleService', () => {
           roles: [{
             createdAt: expect.any(Date),
             disciplineTeacherId: 'deletedDisciplineTeacherId',
+            'disciplineType': {
+              'createdAt': expect.any(Date),
+              'disciplineId': 'nonSelectedDiscipline',
+              'id': 'nonSelectedDiscipline-lecture',
+              'name': 'LECTURE',
+              'updatedAt': expect.any(Date),
+            },
             disciplineTypeId: 'nonSelectedDiscipline-lecture',
-            role: 'LECTURER',
             updatedAt: expect.any(Date),
           }],
           teacher: {
@@ -917,8 +923,14 @@ describe('ScheduleService', () => {
           roles: [{
             createdAt: expect.any(Date),
             disciplineTeacherId: 'deletedDisciplineTeacherId',
+            'disciplineType': {
+              'createdAt': expect.any(Date),
+              'disciplineId': 'nonSelectedDiscipline',
+              'id': 'nonSelectedDiscipline-lecture',
+              'name': 'LECTURE',
+              'updatedAt': expect.any(Date),
+            },
             disciplineTypeId: 'nonSelectedDiscipline-lecture',
-            role: 'LECTURER',
             updatedAt: expect.any(Date),
           }],
           teacher: {

--- a/fictadvisor-api/src/v2/api/services/SubjectService.ts
+++ b/fictadvisor-api/src/v2/api/services/SubjectService.ts
@@ -90,7 +90,11 @@ export class SubjectService {
       include: {
         disciplineTeachers: {
           include: {
-            roles: true,
+            roles: {
+              include: {
+                disciplineType: true,
+              },
+            },
             questionAnswers: {
               where: {
                 disciplineTeacher: {

--- a/fictadvisor-api/src/v2/api/services/TeacherService.ts
+++ b/fictadvisor-api/src/v2/api/services/TeacherService.ts
@@ -26,7 +26,9 @@ import { GroupRepository } from '../../database/repositories/GroupRepository';
 import { ContactRepository } from '../../database/repositories/ContactRepository';
 import { InvalidQueryException } from '../../utils/exceptions/InvalidQueryException';
 import { InvalidEntityIdException } from '../../utils/exceptions/InvalidEntityIdException';
-import { EntityType, QuestionDisplay, Prisma, TeacherRole } from '@prisma/client';
+import { EntityType, QuestionDisplay, Prisma } from '@prisma/client';
+import { TeacherRole } from '@fictadvisor/utils/enums';
+import { TeacherTypeAdapter } from '../../mappers/TeacherRoleAdapter';
 
 @Injectable()
 export class TeacherService {
@@ -92,7 +94,9 @@ export class TeacherService {
       disciplineTeachers: {
         some: {
           roles: {
-            some: DatabaseUtils.getSearchByArray(roles, 'role'),
+            some: {
+              disciplineType: DatabaseUtils.getSearchByArray(roles.map((role) => TeacherTypeAdapter[role]), 'name'),
+            },
           },
         },
       },

--- a/fictadvisor-api/src/v2/database/entities/DbDisciplineTeacherRole.ts
+++ b/fictadvisor-api/src/v2/database/entities/DbDisciplineTeacherRole.ts
@@ -1,9 +1,9 @@
-import { TeacherRole } from '@fictadvisor/utils/enums';
+import { DbDisciplineType } from './DbDisciplineType';
 
 export class DbDisciplineTeacherRole {
   disciplineTeacherId: string;
   disciplineTypeId: string;
-  role: TeacherRole;
-  createdAt: Date | null;
-  updatedAt: Date | null;
+  disciplineType: DbDisciplineType;
+  createdAt: Date;
+  updatedAt: Date;
 }

--- a/fictadvisor-api/src/v2/database/entities/DbDisciplineTeacherWithAnswers.ts
+++ b/fictadvisor-api/src/v2/database/entities/DbDisciplineTeacherWithAnswers.ts
@@ -1,11 +1,12 @@
-import { Discipline, DisciplineTeacherRole, Question } from '@prisma/client';
+import { Discipline, Question } from '@prisma/client';
+import { DisciplineTypeEnum } from '@fictadvisor/utils';
 
 export class DbDisciplineTeacherWithAnswers {
   id: string;
   teacherId: string;
   disciplineId: string;
   discipline: Discipline;
-  roles: DisciplineTeacherRole[];
+  roles: DisciplineTypeEnum[];
   questionAnswers: {
       disciplineTeacherId: string,
       questionId: string,

--- a/fictadvisor-api/src/v2/database/entities/DbDisciplineType.ts
+++ b/fictadvisor-api/src/v2/database/entities/DbDisciplineType.ts
@@ -2,8 +2,8 @@ import { DisciplineTypeEnum } from '@fictadvisor/utils/enums';
 
 export class DbDisciplineType {
   id: string;
-  disciplineId: DisciplineTypeEnum;
-  name: string;
-  createdAt: Date | null;
-  updatedAt: Date | null;
+  disciplineId: string;
+  name: DisciplineTypeEnum;
+  createdAt: Date;
+  updatedAt: Date;
 }

--- a/fictadvisor-api/src/v2/database/repositories/DisciplineRepository.ts
+++ b/fictadvisor-api/src/v2/database/repositories/DisciplineRepository.ts
@@ -25,7 +25,11 @@ export class DisciplineRepository {
             },
           },
         },
-        roles: true,
+        roles: {
+          include: {
+            disciplineType: true,
+          },
+        },
       },
     },
   };

--- a/fictadvisor-api/src/v2/database/repositories/DisciplineTeacherRepository.ts
+++ b/fictadvisor-api/src/v2/database/repositories/DisciplineTeacherRepository.ts
@@ -14,7 +14,11 @@ export class DisciplineTeacherRepository {
         disciplineTypes: true,
       },
     },
-    roles: true,
+    roles: {
+      include: {
+        disciplineType: true,
+      },
+    },
     teacher: {
       include: {
         cathedras: {

--- a/fictadvisor-api/src/v2/database/repositories/DisciplineTeacherRoleRepository.ts
+++ b/fictadvisor-api/src/v2/database/repositories/DisciplineTeacherRoleRepository.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '../PrismaService';
-import { TeacherRole } from '@prisma/client';
 import { CreateDisciplineTeacherRoleData } from '../../api/datas/CreateDisciplineTeacherRoleData';
+import { Prisma } from '@prisma/client';
 
 @Injectable()
 export class DisciplineTeacherRoleRepository {
@@ -9,15 +9,21 @@ export class DisciplineTeacherRoleRepository {
     private prisma: PrismaService,
   ) {}
 
+  private include: Prisma.DisciplineTeacherRoleInclude = {
+    disciplineType: true,
+  };
+
   async find (data: CreateDisciplineTeacherRoleData) {
     return this.prisma.disciplineTeacherRole.findFirst({
       where: data,
+      include: this.include,
     });
   }
 
-  async create (data: { role: TeacherRole; disciplineTeacherId: string; disciplineTypeId: string }) {
+  async create (data: { disciplineTeacherId: string; disciplineTypeId: string }) {
     return this.prisma.disciplineTeacherRole.create({
       data,
+      include: this.include,
     });
   }
 

--- a/fictadvisor-api/src/v2/database/repositories/TeacherRepository.ts
+++ b/fictadvisor-api/src/v2/database/repositories/TeacherRepository.ts
@@ -19,7 +19,11 @@ export class TeacherRepository {
     disciplineTeachers: {
       include: {
         discipline: true,
-        roles: true,
+        roles: {
+          include: {
+            disciplineType: true,
+          },
+        },
       },
     },
   };
@@ -40,7 +44,7 @@ export class TeacherRepository {
     }) as any as DbTeacher;
   }
 
-  async findById (id: string) {
+  async findById (id: string): Promise<DbTeacher> {
     return this.prisma.teacher.findUnique({
       where: {
         id,
@@ -51,7 +55,7 @@ export class TeacherRepository {
 
   async create (
     data: Prisma.TeacherUncheckedCreateInput,
-  ) {
+  ): Promise<DbTeacher> {
     return this.prisma.teacher.create({
       data,
       include: this.include,
@@ -60,7 +64,7 @@ export class TeacherRepository {
 
   async getOrCreate (
     data: {lastName: string, firstName: string, middleName: string},
-  ) {
+  ): Promise<DbTeacher> {
     const teacher = await this.find(data);
     if (!teacher) {
       return this.create(data);
@@ -68,7 +72,7 @@ export class TeacherRepository {
     return teacher;
   }
 
-  async update (where: Prisma.TeacherWhereUniqueInput, data: Prisma.TeacherUncheckedUpdateInput) {
+  async update (where: Prisma.TeacherWhereUniqueInput, data: Prisma.TeacherUncheckedUpdateInput): Promise<DbTeacher> {
     return this.prisma.teacher.update({
       where,
       data,
@@ -76,7 +80,7 @@ export class TeacherRepository {
     }) as any as DbTeacher;
   }
 
-  async updateById (id: string, data: Prisma.TeacherUncheckedUpdateInput) {
+  async updateById (id: string, data: Prisma.TeacherUncheckedUpdateInput): Promise<DbTeacher> {
     return this.prisma.teacher.update({
       where: {
         id,
@@ -86,16 +90,14 @@ export class TeacherRepository {
     }) as any as DbTeacher;
   }
 
-  async delete (where: Prisma.TeacherWhereUniqueInput) {
+  async delete (where: Prisma.TeacherWhereUniqueInput): Promise<DbTeacher> {
     return this.prisma.teacher.delete({
       where,
       include: this.include,
     }) as any as DbTeacher;
   }
 
-  async deleteById (
-    id: string,
-  ) {
+  async deleteById (id: string): Promise<DbTeacher> {
     return this.prisma.teacher.delete({
       where: {
         id,
@@ -104,7 +106,7 @@ export class TeacherRepository {
     }) as any as DbTeacher;
   }
 
-  async count (data: Prisma.TeacherCountArgs) {
+  async count (data: Prisma.TeacherCountArgs): Promise<number> {
     return this.prisma.teacher.count(
       data,
     );

--- a/fictadvisor-api/src/v2/mappers/DisciplineMapper.ts
+++ b/fictadvisor-api/src/v2/mappers/DisciplineMapper.ts
@@ -8,6 +8,7 @@ import {
 } from '@fictadvisor/utils/responses';
 import { AcademicStatus, ScientificDegree, Position } from '@fictadvisor/utils/enums';
 import { DbDisciplineTeacher } from '../database/entities/DbDisciplineTeacher';
+import { getTeacherRoles } from './TeacherRoleAdapter';
 
 @Injectable()
 export class DisciplineMapper {
@@ -50,7 +51,7 @@ export class DisciplineMapper {
         position: teacher.position as Position,
         rating: +teacher.rating,
         disciplineTeacherId: disciplineTeacher.id,
-        roles: disciplineTeacher.roles.map((r) => r.role),
+        roles: getTeacherRoles(disciplineTeacher.roles),
         cathedras: teacher.cathedras.map(({ cathedra: { id, name, abbreviation, division } }) => ({
           id,
           name,
@@ -126,7 +127,7 @@ export class DisciplineMapper {
     });
   }
 
-  getSelectiveDisciplines (disciplines: DbDiscipline[], withAmount = false): 
+  getSelectiveDisciplines (disciplines: DbDiscipline[], withAmount = false):
     SelectiveDisciplinesWithAmountResponse[] | SelectiveDisciplinesResponse[] {
     const result = [];
     disciplines.forEach((discipline) => {

--- a/fictadvisor-api/src/v2/mappers/ScheduleMapper.ts
+++ b/fictadvisor-api/src/v2/mappers/ScheduleMapper.ts
@@ -10,7 +10,6 @@ import { some } from '../utils/ArrayUtil';
 import { DbEvent } from '../database/entities/DbEvent';
 import { DbDiscipline } from '../database/entities/DbDiscipline';
 import { DbDisciplineType } from '../database/entities/DbDisciplineType';
-import { TeacherRoleAdapter } from './TeacherRoleAdapter';
 
 @Injectable()
 export class ScheduleMapper {
@@ -49,7 +48,7 @@ export class ScheduleMapper {
       eventInfo: event.eventInfo[0]?.description || null,
       disciplineInfo: discipline?.description || null,
       teachers: discipline?.disciplineTeachers
-        .filter(({ roles }) => some(roles, 'role', TeacherRoleAdapter[disciplineType]))
+        .filter(({ roles }) => some(roles.map(({ disciplineType }) => disciplineType), 'name', disciplineType))
         .map(({ teacher }) => ({
           id: teacher.id,
           firstName: teacher.firstName,
@@ -95,6 +94,6 @@ export class ScheduleMapper {
   }
 
   private getEventType (disciplineType: DbDisciplineType) {
-    return disciplineType?.name as EventTypeEnum ?? EventTypeEnum.OTHER;
+    return disciplineType?.name as unknown as EventTypeEnum ?? EventTypeEnum.OTHER;
   }
 }

--- a/fictadvisor-api/src/v2/mappers/TeacherMapper.ts
+++ b/fictadvisor-api/src/v2/mappers/TeacherMapper.ts
@@ -9,6 +9,7 @@ import {
   Position,
 } from '@fictadvisor/utils/enums';
 import { DbTeacher } from '../database/entities/DbTeacher';
+import { getTeacherRoles } from './TeacherRoleAdapter';
 
 @Injectable()
 export class TeacherMapper {
@@ -35,8 +36,8 @@ export class TeacherMapper {
 
   getRoles (teacher: DbTeacher): TeacherRole[] {
     const roles: TeacherRole[] = [];
-    for (const dt of teacher.disciplineTeachers) {
-      roles.push(...dt.roles.map(({ role }) => role));
+    for (const disciplineTeacher of teacher.disciplineTeachers) {
+      roles.push(...getTeacherRoles(disciplineTeacher.roles));
     }
 
     return [...new Set(roles)];

--- a/fictadvisor-api/src/v2/mappers/TeacherRoleAdapter.ts
+++ b/fictadvisor-api/src/v2/mappers/TeacherRoleAdapter.ts
@@ -1,4 +1,6 @@
-import { DisciplineTypeEnum, TeacherRole } from '@prisma/client';
+import { DisciplineTypeEnum } from '@prisma/client';
+import { TeacherRole } from '@fictadvisor/utils/enums';
+import { DbDisciplineTeacherRole } from '../database/entities/DbDisciplineTeacherRole';
 
 export const TeacherRoleAdapter: {[key in keyof typeof DisciplineTypeEnum]?: TeacherRole | never} = {
   [DisciplineTypeEnum.LECTURE]: TeacherRole.LECTURER,
@@ -8,6 +10,9 @@ export const TeacherRoleAdapter: {[key in keyof typeof DisciplineTypeEnum]?: Tea
   [DisciplineTypeEnum.CONSULTATION]: TeacherRole.OTHER,
   [DisciplineTypeEnum.WORKOUT]: TeacherRole.OTHER,
 };
+
+export const getTeacherRoles = (disciplineTeacherRoles: DbDisciplineTeacherRole[]) =>
+  disciplineTeacherRoles.map(({ disciplineType }) => TeacherRoleAdapter[disciplineType.name]);
 
 export const TeacherTypeAdapter: {[key in keyof typeof TeacherRole]?: DisciplineTypeEnum | never} = {
   [TeacherRole.LECTURER]: DisciplineTypeEnum.LECTURE,

--- a/fictadvisor-api/src/v2/utils/parser/CampusParser.ts
+++ b/fictadvisor-api/src/v2/utils/parser/CampusParser.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { Parser } from './Parser';
 import axios from 'axios';
-import { DisciplineTypeEnum, TeacherRole } from '@prisma/client';
+import { DisciplineTypeEnum } from '@prisma/client';
 import { ScheduleDayType, ScheduleGroupType, SchedulePairType, ScheduleType } from './ScheduleParserTypes';
 import { DateService, StudyingSemester } from '../date/DateService';
 import { DbSubject } from '../../database/entities/DbSubject';
@@ -13,6 +13,8 @@ import { DisciplineTeacherRepository } from '../../database/repositories/Discipl
 import { SubjectRepository } from '../../database/repositories/SubjectRepository';
 import { GroupRepository } from '../../database/repositories/GroupRepository';
 import { GeneralParser } from './GeneralParser';
+import { TeacherRole } from '@fictadvisor/utils/enums';
+import { TeacherTypeAdapter } from '../../mappers/TeacherRoleAdapter';
 
 export const DAY_NUMBER = {
   'Пн': 1,
@@ -178,16 +180,14 @@ export class CampusParser implements Parser {
         disciplineId: discipline.id,
         roles: {
           create: {
-            role,
             disciplineTypeId: disciplineType.id,
           },
         },
       });
-    } else if (!disciplineTeacher.roles.some((r) => r.role === role)) {
+    } else if (!disciplineTeacher.roles.some((r) => r.disciplineType.name === TeacherTypeAdapter[role])) {
       await this.disciplineTeacherRepository.updateById(disciplineTeacher.id, {
         roles: {
           create: {
-            role,
             disciplineTypeId: disciplineType.id,
           },
         },

--- a/fictadvisor-api/src/v2/utils/parser/RozParser.ts
+++ b/fictadvisor-api/src/v2/utils/parser/RozParser.ts
@@ -2,7 +2,7 @@ import axios from 'axios';
 import { JSDOM } from 'jsdom';
 import { Injectable } from '@nestjs/common';
 import { Parser } from './Parser';
-import { DisciplineTypeEnum, TeacherRole } from '@prisma/client';
+import { DisciplineTypeEnum } from '@prisma/client';
 import { DisciplineTeacherRepository } from '../../database/repositories/DisciplineTeacherRepository';
 import { DisciplineTeacherRoleRepository } from '../../database/repositories/DisciplineTeacherRoleRepository';
 import { GroupRepository } from '../../database/repositories/GroupRepository';
@@ -25,6 +25,7 @@ import { ExtendedSchedulePair } from './ScheduleParserTypes';
 import { DbDiscipline } from '../../database/entities/DbDiscipline';
 import { DbDisciplineType } from '../../database/entities/DbDisciplineType';
 import { GeneralParser } from './GeneralParser';
+import { TeacherRole } from '@fictadvisor/utils/enums';
 
 const DISCIPLINE_TYPE = {
   Лек: DisciplineTypeEnum.LECTURE,
@@ -207,7 +208,7 @@ export class RozParser implements Parser {
 
     const disciplineType = discipline.disciplineTypes.find((type) => type.name === name);
 
-    await this.handleTeachers(pair, discipline, role, disciplineType);
+    await this.handleTeachers(pair, discipline, disciplineType);
 
     await this.generalParser.handleEvent(pair, startOfEvent, endOfEvent, groupId, disciplineType.id);
   }
@@ -242,7 +243,6 @@ export class RozParser implements Parser {
   async handleTeachers (
     pair: ExtendedSchedulePair,
     discipline: DbDiscipline,
-    role: TeacherRole,
     disciplineType: DbDisciplineType,
   ) {
     pair.teacher = pair.teacher ? pair.teacher : { lastName: '', firstName: '', middleName: '' };
@@ -257,7 +257,6 @@ export class RozParser implements Parser {
       });
 
       await this.disciplineTeacherRoleRepository.getOrCreate({
-        role,
         disciplineTeacherId: disciplineTeacher.id,
         disciplineTypeId: disciplineType.id,
       });

--- a/utils/src/requests/UpdateDisciplineTeacherDTO.ts
+++ b/utils/src/requests/UpdateDisciplineTeacherDTO.ts
@@ -4,7 +4,8 @@ import { TeacherRole } from '../enums/db/TeacherRoleEnum';
 
 export class UpdateDisciplineTeacherDTO {
   @ApiProperty({
-    enum: [TeacherRole],
+    enum: TeacherRole,
+    type: [TeacherRole],
   })
   @IsNotEmpty()
   @IsArray()

--- a/utils/src/responses/DisciplineTeacherCreateResponse.ts
+++ b/utils/src/responses/DisciplineTeacherCreateResponse.ts
@@ -36,19 +36,6 @@ class Discipline extends DisciplineResponse {
     disciplineTypes: DisciplineType[];
 }
 
-class DisciplineTeacherRole {
-  @ApiProperty()
-    disciplineTeacherId: string;
-
-  @ApiProperty()
-    disciplineTypeId: string;
-
-  @ApiProperty({
-    enum: TeacherRole,
-  })
-    role: TeacherRole;
-}
-
 export class DisciplineTeacherCreateResponse {
   @ApiProperty()
     id: string;
@@ -70,7 +57,8 @@ export class DisciplineTeacherCreateResponse {
     teacher: TeacherResponse;
 
   @ApiProperty({
-    type: [DisciplineTeacherRole],
+    enum: TeacherRole,
+    type: [TeacherRole],
   })
-    roles: DisciplineTeacherRole[];
+    roles: TeacherRole[];
 }


### PR DESCRIPTION
- updated database entities and repositories
- updated disciplineTeacher mappers
- updated swagger documentation
- refactored create and updateById methods of DisciplineTeacherService
- removed DisciplineTeacherRoleRepository

closes #116 