### PR TITLE
enhancement #281: updated poll endpoints for telegram

### DIFF
--- a/fictadvisor-api/src/v2/api/controllers/PollController.ts
+++ b/fictadvisor-api/src/v2/api/controllers/PollController.ts
@@ -24,6 +24,7 @@ import { QueryAllQuestionDTO } from '../dtos/QueryAllQuestionDTO';
 import { CreateQuestionDTO } from '../dtos/CreateQuestionDTO';
 import { UpdateQuestionDTO } from '../dtos/UpdateQuestionDTO';
 import { QuestionResponse, PaginatedQuestionsResponse } from '../responses/QuestionResponse';
+import { TelegramGuard } from '../../security/TelegramGuard';
 
 @ApiTags('Poll')
 @Controller({
@@ -142,6 +143,7 @@ export class PollController {
   @ApiEndpoint({
     summary: 'Get teachers that were polled by the user',
     permissions: PERMISSION.USERS_$USERID_POLL_TEACHERS_GET,
+    guards: TelegramGuard,
   })
   @Get('/teachers/:userId')
   async getPollDisciplineTeachers (
@@ -186,7 +188,6 @@ export class PollController {
     const question = await this.pollService.deleteById(questionId);
     return this.questionMapper.getQuestion(question);
   }
-
 
   @ApiBearerAuth()
   @ApiOkResponse({

--- a/fictadvisor-api/src/v2/api/dtos/CreateAnswersDTO.ts
+++ b/fictadvisor-api/src/v2/api/dtos/CreateAnswersDTO.ts
@@ -5,19 +5,28 @@ import { ApiProperty } from '@nestjs/swagger';
 
 export class CreateAnswerDTO {
   @ApiProperty()
-  @IsNotEmpty(validationOptionsMsg('Question id can not be empty'))
+  @IsNotEmpty(validationOptionsMsg('Question id cannot be empty'))
     questionId: string;
   
   @ApiProperty()
-  @IsNotEmpty(validationOptionsMsg('Value can not be empty'))
+  @IsNotEmpty(validationOptionsMsg('Value cannot be empty'))
     value: string;
 }
 
 export class CreateAnswersDTO {
   @ApiProperty({
     type: [CreateAnswerDTO],
+    description: 'Array of the question\'s answers',
   })
   @Type(() => CreateAnswerDTO)
   @ValidateNested({ each: true })
     answers: CreateAnswerDTO[];
+}
+
+export class CreateAnswersWithUserIdDTO extends CreateAnswersDTO {
+  @ApiProperty({
+    description: 'Id of the user who provided answers',
+  })
+  @IsNotEmpty(validationOptionsMsg('UserId cannot be empty'))
+    userId: string;
 }

--- a/fictadvisor-api/src/v2/api/responses/DisciplineTeacherQuestionsResponse.ts
+++ b/fictadvisor-api/src/v2/api/responses/DisciplineTeacherQuestionsResponse.ts
@@ -1,41 +1,42 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { QuestionResponse } from './QuestionResponse';
 import { TeacherResponse } from './TeacherResponse';
+import { SubjectResponse } from './SubjectResponse';
 
 class Category {
-  @ApiProperty()
+  @ApiProperty({
+    description: 'Categories name',
+  })
     name: string;
 
-  @ApiProperty()
+  @ApiProperty({
+    description: 'Number of questions in this category',
+  })
     count: number;
 
   @ApiProperty({
     type: [QuestionResponse],
+    description: 'Array of questions of this category',
   })
     questions: QuestionResponse[];
-}
-
-class Subject {
-  @ApiProperty()
-    id: string;
-
-  @ApiProperty()
-    name: string;
 }
 
 export class DisciplineTeacherQuestionsResponse {
   @ApiProperty({
     type: TeacherResponse,
+    description: 'The teacher to whom the question belongs',
   })
     teacher: TeacherResponse;
   
   @ApiProperty({
-    type: Subject,
+    description: 'The subject of the teacher',
+    type: SubjectResponse,
   })
-    subject: Subject;
+    subject: SubjectResponse;
 
   @ApiProperty({
     type: [Category],
+    description: 'An array of categories with questions',
   })
     categories: Category[];
 }

--- a/fictadvisor-api/src/v2/api/services/DisciplineTeacherService.ts
+++ b/fictadvisor-api/src/v2/api/services/DisciplineTeacherService.ts
@@ -109,7 +109,7 @@ export class DisciplineTeacherService {
     const questions = await this.getUniqueQuestions(id);
     const categories = this.questionMapper.sortByCategories(questions);
     return {
-      teacher,
+      teacher: { ...teacher, rating: +teacher.rating },
       subject: discipline.subject,
       categories,
     };

--- a/fictadvisor-api/src/v2/modules/AccessModule.ts
+++ b/fictadvisor-api/src/v2/modules/AccessModule.ts
@@ -11,6 +11,7 @@ import { ConfigurationModule } from './ConfigModule';
 import { SecurityConfigService } from '../config/SecurityConfigService';
 import { JwtModule } from '@nestjs/jwt';
 import { PermissionService } from '../api/services/PermissionService';
+import { TelegramConfigService } from '../config/TelegramConfigService';
 
 @Module({
   providers: [
@@ -21,6 +22,7 @@ import { PermissionService } from '../api/services/PermissionService';
     GroupByEventGuard,
     JwtStrategy,
     TelegramGuard,
+    TelegramConfigService,
     PermissionService,
   ],
   exports: [
@@ -31,6 +33,7 @@ import { PermissionService } from '../api/services/PermissionService';
     GroupByEventGuard,
     JwtStrategy,
     TelegramGuard,
+    TelegramConfigService,
     PermissionService,
     JwtModule,
   ],


### PR DESCRIPTION
- added Telegram Guard to /v2/poll/teachers/{userId} and /v2/disciplineTeachers/{disciplineTeacherId}/questions endpoints
- created endpoint like /v2/disciplineTeachers/{disciplineTeacherId}/answers with userId in body

closes #281
