### PR TITLE
migration #408: replaced disciplineTeacherRole usage with disciplineType

### DIFF
--- a/fictadvisor-api/prisma/migrations/20240709195316_replace_discipline_teacher_roles/migration.sql
+++ b/fictadvisor-api/prisma/migrations/20240709195316_replace_discipline_teacher_roles/migration.sql
@@ -1,0 +1,30 @@
+/*
+  Warnings:
+
+  - The primary key for the `discipline_teacher_roles` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - You are about to drop the column `role` on the `discipline_teacher_roles` table. All the data in the column will be lost.
+  - The primary key for the `question_roles` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - Changed the type of `role` on the `question_roles` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+
+*/
+-- AlterTable
+ALTER TABLE "discipline_teacher_roles"
+    DROP CONSTRAINT "discipline_teacher_roles_pkey",
+    DROP COLUMN "role",
+    ADD CONSTRAINT "discipline_teacher_roles_pkey" PRIMARY KEY ("discipline_teacher_id", "discipline_type_id");
+
+-- AlterTable
+ALTER TABLE "question_roles"
+    ALTER COLUMN "role" TYPE text;
+
+UPDATE "question_roles"
+SET "role" = CASE
+                 WHEN "role" = 'LECTURER' THEN 'LECTURE'
+                 WHEN "role" = 'PRACTICIAN' THEN 'PRACTICE'
+                 WHEN "role" = 'LABORANT' THEN 'LABORATORY'
+                 WHEN "role" = 'EXAMINER' THEN 'EXAM'
+                 ELSE 'LECTURE'
+    END;
+
+ALTER TABLE "question_roles"
+    ALTER COLUMN "role" TYPE "DisciplineTypeEnum" USING "role"::"DisciplineTypeEnum"

--- a/fictadvisor-api/prisma/schema.prisma
+++ b/fictadvisor-api/prisma/schema.prisma
@@ -293,13 +293,13 @@ model Question {
 }
 
 model QuestionRole {
-  role       TeacherRole
-  question   Question    @relation(fields: [questionId], references: [id], onDelete: Cascade)
-  questionId String      @map("question_id")
-  isShown    Boolean     @map("is_shown")
-  isRequired Boolean     @map("is_required")
-  createdAt  DateTime?   @default(now()) @map("created_at")
-  updatedAt  DateTime?   @default(now()) @updatedAt @map("updated_at")
+  role       DisciplineTypeEnum
+  question   Question           @relation(fields: [questionId], references: [id], onDelete: Cascade)
+  questionId String             @map("question_id")
+  isShown    Boolean            @map("is_shown")
+  isRequired Boolean            @map("is_required")
+  createdAt  DateTime?          @default(now()) @map("created_at")
+  updatedAt  DateTime?          @default(now()) @updatedAt @map("updated_at")
 
   @@id([questionId, role])
   @@map("question_roles")
@@ -405,11 +405,10 @@ model DisciplineTeacherRole {
   disciplineTeacherId String            @map("discipline_teacher_id")
   disciplineType      DisciplineType    @relation(fields: [disciplineTypeId], references: [id], onDelete: Cascade)
   disciplineTypeId    String            @map("discipline_type_id")
-  role                TeacherRole
   createdAt           DateTime?         @default(now()) @map("created_at")
   updatedAt           DateTime?         @default(now()) @updatedAt @map("updated_at")
 
-  @@id([disciplineTeacherId, disciplineTypeId, role])
+  @@id([disciplineTeacherId, disciplineTypeId])
   @@map("discipline_teacher_roles")
 }
 

--- a/fictadvisor-api/src/v2/api/controllers/PollController.ts
+++ b/fictadvisor-api/src/v2/api/controllers/PollController.ts
@@ -29,7 +29,7 @@ import { QuestionByRoleAndIdPipe } from '../pipes/QuestionByRoleAndIdPipe';
 import { UserByIdPipe } from '../pipes/UserByIdPipe';
 import { QuestionMapper } from '../../mappers/QuestionMapper';
 import { PollService } from '../services/PollService';
-import { TeacherRole } from '@prisma/client';
+import { TeacherRole } from '@fictadvisor/utils';
 
 @ApiTags('Poll')
 @Controller({

--- a/fictadvisor-api/src/v2/api/datas/CreateDisciplineTeacherRoleData.ts
+++ b/fictadvisor-api/src/v2/api/datas/CreateDisciplineTeacherRoleData.ts
@@ -1,4 +1,4 @@
-import { TeacherRole } from '@prisma/client';
+import { TeacherRole } from '@fictadvisor/utils';
 
 export interface CreateDisciplineTeacherRoleData {
   role: TeacherRole,

--- a/fictadvisor-api/src/v2/api/pipes/QuestionByRoleAndIdPipe.ts
+++ b/fictadvisor-api/src/v2/api/pipes/QuestionByRoleAndIdPipe.ts
@@ -1,7 +1,8 @@
 import { Injectable, PipeTransform } from '@nestjs/common';
 import { QuestionRepository } from '../../database/repositories/QuestionRepository';
 import { InvalidEntityIdException } from '../../utils/exceptions/InvalidEntityIdException';
-import { TeacherRole } from '@prisma/client';
+import { TeacherRole } from '@fictadvisor/utils';
+import { TeacherTypeAdapter } from '../../mappers/TeacherRoleAdapter';
 
 @Injectable()
 export class QuestionByRoleAndIdPipe implements PipeTransform {
@@ -15,7 +16,7 @@ export class QuestionByRoleAndIdPipe implements PipeTransform {
     if (!question) {
       throw new InvalidEntityIdException('question');
     }
-    if (!question.questionRoles.some((r) => r.role === role)) {
+    if (!question.questionRoles.some((r) => r.role === TeacherTypeAdapter[role])) {
       throw new InvalidEntityIdException('questionRole');
     }
     return params;

--- a/fictadvisor-api/src/v2/api/services/DisciplineService.ts
+++ b/fictadvisor-api/src/v2/api/services/DisciplineService.ts
@@ -119,11 +119,6 @@ export class DisciplineService {
     const role = TeacherRoleAdapter[disciplineType];
     const disciplineTeachers = await this.disciplineTeacherRepository.findMany({
       where: {
-        roles: {
-          some: {
-            role,
-          },
-        },
         discipline: {
           id: disciplineId,
         },

--- a/fictadvisor-api/src/v2/api/services/DisciplineTeacherService.ispec.ts
+++ b/fictadvisor-api/src/v2/api/services/DisciplineTeacherService.ispec.ts
@@ -15,7 +15,8 @@ import { AlreadyAnsweredException } from '../../utils/exceptions/AlreadyAnswered
 import { WrongTimeException } from '../../utils/exceptions/WrongTimeException';
 import { NoPermissionException } from '../../utils/exceptions/NoPermissionException';
 import { IsRemovedDisciplineTeacherException } from '../../utils/exceptions/IsRemovedDisciplineTeacherException';
-import { Discipline, QuestionType, State, TeacherRole } from '@prisma/client';
+import { Discipline, QuestionType, State } from '@prisma/client';
+import { DisciplineTypeEnum } from '@fictadvisor/utils';
 
 describe('DisciplineTeacherService', () => {
   let disciplineTeacherService: DisciplineTeacherService;
@@ -130,7 +131,7 @@ describe('DisciplineTeacherService', () => {
           semester: 1,
           year: 2022,
           isSelective: true,
-        }, 
+        },
         selective20222,
       ],
     });
@@ -221,15 +222,12 @@ describe('DisciplineTeacherService', () => {
       data: [{
         disciplineTeacherId: 'lecturerForNonSelective20221Id',
         disciplineTypeId: 'ec7866e2-a426-4e1b-b76c-1ce68fdb46a1',
-        role: 'LECTURER',
       }, {
         disciplineTeacherId: 'removedId1',
         disciplineTypeId: 'ec7866e2-a426-4e1b-b76c-1ce68fdb46a1',
-        role: 'LECTURER',
       }, {
         disciplineTeacherId: 'lecturerForNonSelective20222Id',
         disciplineTypeId: 'f3717ce9-cd52-4c40-889a-094a9b6a01de',
-        role: 'LECTURER',
       }],
     });
 
@@ -277,25 +275,25 @@ describe('DisciplineTeacherService', () => {
     await prismaService.questionRole.createMany({
       data: [
         {
-          role: TeacherRole.LECTURER,
+          role: DisciplineTypeEnum.LECTURE,
           questionId: 'lecturerQuestionId1',
           isShown: true,
           isRequired: true,
         },
         {
-          role: TeacherRole.LECTURER,
+          role: DisciplineTypeEnum.LECTURE,
           questionId: 'lecturerQuestionId2',
           isShown: true,
           isRequired: true,
         },
         {
-          role: TeacherRole.PRACTICIAN,
+          role: DisciplineTypeEnum.PRACTICE,
           questionId: 'practicianQuestionId',
           isShown: true,
           isRequired: false,
         },
         {
-          role: TeacherRole.LECTURER,
+          role: DisciplineTypeEnum.LECTURE,
           questionId: 'lecturerQuestionId3',
           isShown: true,
           isRequired: false,

--- a/fictadvisor-api/src/v2/api/services/DisciplineTeacherService.ts
+++ b/fictadvisor-api/src/v2/api/services/DisciplineTeacherService.ts
@@ -15,7 +15,7 @@ import { DbDiscipline } from '../../database/entities/DbDiscipline';
 import { DbQuestionAnswer } from '../../database/entities/DbQuestionAnswer';
 import { DatabaseUtils } from '../../database/DatabaseUtils';
 import { PaginatedData } from '../datas/PaginatedData';
-import { TeacherTypeAdapter } from '../../mappers/TeacherRoleAdapter';
+import { TeacherRoleAdapter, TeacherTypeAdapter } from '../../mappers/TeacherRoleAdapter';
 import { QuestionMapper } from '../../mappers/QuestionMapper';
 import { PollService } from './PollService';
 import { DateService } from '../../utils/date/DateService';
@@ -33,7 +33,8 @@ import { InvalidEntityIdException } from '../../utils/exceptions/InvalidEntityId
 import { NoPermissionException } from '../../utils/exceptions/NoPermissionException';
 import { NotSelectedDisciplineException } from '../../utils/exceptions/NotSelectedDisciplineException';
 import { IsRemovedDisciplineTeacherException } from '../../utils/exceptions/IsRemovedDisciplineTeacherException';
-import { Prisma, QuestionType, State, TeacherRole } from '@prisma/client';
+import { Prisma, QuestionType, State } from '@prisma/client';
+import { TeacherRole } from '@fictadvisor/utils';
 
 @Injectable()
 export class DisciplineTeacherService {
@@ -131,11 +132,11 @@ export class DisciplineTeacherService {
 
     const teacherRoles = disciplineTeachers
       .find((dt) => dt.id === id)
-      .roles.map((r) => r.role);
+      .roles.map((r) => TeacherRoleAdapter[r.disciplineType.name]);
 
     const disciplineRoles = new Set<TeacherRole>();
     for (const dt of disciplineTeachers) {
-      dt.roles.forEach((r) => disciplineRoles.add(r.role));
+      dt.roles.forEach((r) => disciplineRoles.add(TeacherRoleAdapter[r.disciplineType.name]));
     }
 
     return this.pollService.getQuestions(teacherRoles, Array.from(disciplineRoles));

--- a/fictadvisor-api/src/v2/api/services/PollService.ispec.ts
+++ b/fictadvisor-api/src/v2/api/services/PollService.ispec.ts
@@ -1,5 +1,5 @@
 import { Test } from '@nestjs/testing';
-import { CommentsSortOrder } from '@fictadvisor/utils/enums';
+import { CommentsSortOrder, TeacherRole } from '@fictadvisor/utils/enums';
 import { DateModule } from '../../utils/date/DateModule';
 import { MapperModule } from '../../modules/MapperModule';
 import { PrismaModule } from '../../modules/PrismaModule';
@@ -7,7 +7,8 @@ import { PollService } from './PollService';
 import { DbDiscipline } from 'src/v2/database/entities/DbDiscipline';
 import { DbQuestionWithRoles } from 'src/v2/database/entities/DbQuestionWithRoles';
 import { DbQuestionWithAnswers } from 'src/v2/database/entities/DbQuestionWithAnswers';
-import { Group, PrismaClient, QuestionDisplay, QuestionType, State, Subject, Teacher, TeacherRole, User } from '@prisma/client';
+import { Group, PrismaClient, QuestionDisplay, QuestionType, State, Subject, Teacher, User } from '@prisma/client';
+import { DisciplineTypeEnum } from '@fictadvisor/utils';
 
 
 describe('PollService', () => {
@@ -212,9 +213,9 @@ describe('PollService', () => {
         order: 1,
         questionRoles: {
           createMany: { data: [
-            { role: TeacherRole.LABORANT, isRequired: false, isShown: false },
-            { role: TeacherRole.LECTURER, isRequired: true, isShown: false },
-            { role: TeacherRole.PRACTICIAN, isRequired: true, isShown: true },
+            { role: DisciplineTypeEnum.LABORATORY, isRequired: false, isShown: false },
+            { role: DisciplineTypeEnum.LECTURE, isRequired: true, isShown: false },
+            { role: DisciplineTypeEnum.PRACTICE, isRequired: true, isShown: true },
           ] },
         },
         questionAnswers: {
@@ -249,9 +250,9 @@ describe('PollService', () => {
         order: 2,
         questionRoles: {
           createMany: { data: [
-            { role: TeacherRole.LABORANT, isRequired: true, isShown: true },
-            { role: TeacherRole.LECTURER, isRequired: true, isShown: true },
-            { role: TeacherRole.PRACTICIAN, isRequired: true, isShown: true },
+            { role: DisciplineTypeEnum.LABORATORY, isRequired: true, isShown: true },
+            { role: DisciplineTypeEnum.LECTURE, isRequired: true, isShown: true },
+            { role: DisciplineTypeEnum.PRACTICE, isRequired: true, isShown: true },
           ] },
         },
         questionAnswers: {
@@ -287,9 +288,9 @@ describe('PollService', () => {
         order: 4,
         questionRoles: { createMany: {
           data: [
-            { role: TeacherRole.LABORANT, isRequired: false, isShown: true },
-            { role: TeacherRole.LECTURER, isRequired: false, isShown: true },
-            { role: TeacherRole.PRACTICIAN, isRequired: false, isShown: true },
+            { role: DisciplineTypeEnum.LABORATORY, isRequired: false, isShown: true },
+            { role: DisciplineTypeEnum.LECTURE, isRequired: false, isShown: true },
+            { role: DisciplineTypeEnum.PRACTICE, isRequired: false, isShown: true },
           ],
         } },
         questionAnswers: { createMany: {

--- a/fictadvisor-api/src/v2/api/services/PollService.ts
+++ b/fictadvisor-api/src/v2/api/services/PollService.ts
@@ -13,6 +13,7 @@ import { CommentsSortOrder } from '@fictadvisor/utils/enums';
 import {
   SortQATParam,
   OrderQAParam,
+  TeacherRole,
 } from '@fictadvisor/utils/enums';
 import { DatabaseUtils } from '../../database/DatabaseUtils';
 import { DisciplineTeacherMapper } from '../../mappers/DisciplineTeacherMapper';
@@ -30,9 +31,9 @@ import { GroupRepository } from '../../database/repositories/GroupRepository';
 import {
   QuestionType,
   SemesterDate,
-  TeacherRole,
   Prisma,
 } from '@prisma/client';
+import { TeacherTypeAdapter } from '../../mappers/TeacherRoleAdapter';
 
 @Injectable()
 export class PollService {
@@ -102,13 +103,13 @@ export class PollService {
           some: {
             isShown: true,
             role: {
-              in: roles,
+              in: roles.map((role) => TeacherTypeAdapter[role]),
             },
           },
           none: {
             isRequired: true,
             role: {
-              notIn: disciplineRoles,
+              notIn: disciplineRoles.map((role) => TeacherTypeAdapter[role]),
             },
           },
         },
@@ -220,6 +221,7 @@ export class PollService {
       questionRoles: {
         create: {
           ...data,
+          role: TeacherTypeAdapter[data.role],
         },
       },
     });
@@ -231,7 +233,7 @@ export class PollService {
         delete: {
           questionId_role: {
             questionId: questionId,
-            role: role,
+            role: TeacherTypeAdapter[role],
           },
         },
       },

--- a/fictadvisor-api/src/v2/api/services/ScheduleService.ispec.ts
+++ b/fictadvisor-api/src/v2/api/services/ScheduleService.ispec.ts
@@ -835,8 +835,14 @@ describe('ScheduleService', () => {
           roles: [{
             createdAt: expect.any(Date),
             disciplineTeacherId: 'deletedDisciplineTeacherId',
+            'disciplineType': {
+              'createdAt': expect.any(Date),
+              'disciplineId': 'nonSelectedDiscipline',
+              'id': 'nonSelectedDiscipline-lecture',
+              'name': 'LECTURE',
+              'updatedAt': expect.any(Date),
+            },
             disciplineTypeId: 'nonSelectedDiscipline-lecture',
-            role: 'LECTURER',
             updatedAt: expect.any(Date),
           }],
           teacher: {
@@ -917,8 +923,14 @@ describe('ScheduleService', () => {
           roles: [{
             createdAt: expect.any(Date),
             disciplineTeacherId: 'deletedDisciplineTeacherId',
+            'disciplineType': {
+              'createdAt': expect.any(Date),
+              'disciplineId': 'nonSelectedDiscipline',
+              'id': 'nonSelectedDiscipline-lecture',
+              'name': 'LECTURE',
+              'updatedAt': expect.any(Date),
+            },
             disciplineTypeId: 'nonSelectedDiscipline-lecture',
-            role: 'LECTURER',
             updatedAt: expect.any(Date),
           }],
           teacher: {

--- a/fictadvisor-api/src/v2/api/services/ScheduleService.ts
+++ b/fictadvisor-api/src/v2/api/services/ScheduleService.ts
@@ -212,13 +212,11 @@ export class ScheduleService {
     const { id } = find(discipline.disciplineTypes, 'name', data.eventType);
 
     for (const teacherId of data.teachers) {
-      const role = TeacherRoleAdapter[data.eventType];
       const disciplineTeacher = await this.disciplineTeacherRepository.getOrCreate({ teacherId, disciplineId: discipline.id });
-      if (!some(disciplineTeacher.roles, 'role', role)) {
+      if (!some(disciplineTeacher.roles.map((r) => r.disciplineType), 'name', data.eventType)) {
         await this.disciplineTeacherRoleRepository.create({
           disciplineTeacherId: disciplineTeacher.id,
           disciplineTypeId: id,
-          role,
         });
       }
     }
@@ -652,7 +650,7 @@ export class ScheduleService {
       };
 
       discipline.disciplineTeachers.map(({ teacherId, disciplineId, roles }) => {
-        if (roles.length === 1 && roles[0].role === TeacherRoleAdapter[type.name]) {
+        if (roles.length === 1 && roles[0].disciplineType.name === type.name) {
           update.disciplineTeachers.deleteMany.OR.push({
             teacherId,
             disciplineId,
@@ -702,13 +700,11 @@ export class ScheduleService {
     await this.removeTeachers(removedTeachers, disciplineType.id);
 
     for (const teacherId of teachers) {
-      const role = TeacherRoleAdapter[disciplineType.name];
       const disciplineTeacher = await this.disciplineTeacherRepository.getOrCreate({ teacherId, disciplineId });
-      if (!some(disciplineTeacher.roles, 'role', role)) {
+      if (!some(disciplineTeacher.roles.map((r) => r.disciplineType), 'name', disciplineType.name)) {
         await this.disciplineTeacherRoleRepository.create({
           disciplineTeacherId: disciplineTeacher.id,
           disciplineTypeId: disciplineType.id,
-          role,
         });
       }
     }

--- a/fictadvisor-api/src/v2/api/services/TeacherService.ts
+++ b/fictadvisor-api/src/v2/api/services/TeacherService.ts
@@ -26,7 +26,8 @@ import { GroupRepository } from '../../database/repositories/GroupRepository';
 import { ContactRepository } from '../../database/repositories/ContactRepository';
 import { InvalidQueryException } from '../../utils/exceptions/InvalidQueryException';
 import { InvalidEntityIdException } from '../../utils/exceptions/InvalidEntityIdException';
-import { EntityType, QuestionDisplay, Prisma, TeacherRole } from '@prisma/client';
+import { EntityType, QuestionDisplay, Prisma } from '@prisma/client';
+import { TeacherRole } from '@fictadvisor/utils';
 
 @Injectable()
 export class TeacherService {

--- a/fictadvisor-api/src/v2/database/entities/DbDisciplineTeacherRole.ts
+++ b/fictadvisor-api/src/v2/database/entities/DbDisciplineTeacherRole.ts
@@ -1,9 +1,9 @@
-import { TeacherRole } from '@fictadvisor/utils/enums';
+import { DbDisciplineType } from './DbDisciplineType';
 
 export class DbDisciplineTeacherRole {
   disciplineTeacherId: string;
   disciplineTypeId: string;
-  role: TeacherRole;
+  disciplineType: DbDisciplineType;
   createdAt: Date | null;
   updatedAt: Date | null;
 }

--- a/fictadvisor-api/src/v2/database/repositories/DisciplineRepository.ts
+++ b/fictadvisor-api/src/v2/database/repositories/DisciplineRepository.ts
@@ -25,7 +25,11 @@ export class DisciplineRepository {
             },
           },
         },
-        roles: true,
+        roles: {
+          include: {
+            disciplineType: true,
+          },
+        },
       },
     },
   };

--- a/fictadvisor-api/src/v2/database/repositories/DisciplineTeacherRepository.ts
+++ b/fictadvisor-api/src/v2/database/repositories/DisciplineTeacherRepository.ts
@@ -14,7 +14,11 @@ export class DisciplineTeacherRepository {
         disciplineTypes: true,
       },
     },
-    roles: true,
+    roles: {
+      include: {
+        disciplineType: true,
+      },
+    },
     teacher: {
       include: {
         cathedras: {

--- a/fictadvisor-api/src/v2/database/repositories/DisciplineTeacherRoleRepository.ts
+++ b/fictadvisor-api/src/v2/database/repositories/DisciplineTeacherRoleRepository.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '../PrismaService';
-import { TeacherRole } from '@prisma/client';
+import { TeacherRole } from '@fictadvisor/utils';
 import { CreateDisciplineTeacherRoleData } from '../../api/datas/CreateDisciplineTeacherRoleData';
 
 @Injectable()
@@ -15,7 +15,7 @@ export class DisciplineTeacherRoleRepository {
     });
   }
 
-  async create (data: { role: TeacherRole; disciplineTeacherId: string; disciplineTypeId: string }) {
+  async create (data: { disciplineTeacherId: string; disciplineTypeId: string }) {
     return this.prisma.disciplineTeacherRole.create({
       data,
     });

--- a/fictadvisor-api/src/v2/mappers/DisciplineMapper.ts
+++ b/fictadvisor-api/src/v2/mappers/DisciplineMapper.ts
@@ -8,6 +8,7 @@ import {
 } from '@fictadvisor/utils/responses';
 import { AcademicStatus, ScientificDegree, Position } from '@fictadvisor/utils/enums';
 import { DbDisciplineTeacher } from '../database/entities/DbDisciplineTeacher';
+import { TeacherRoleAdapter } from './TeacherRoleAdapter';
 
 @Injectable()
 export class DisciplineMapper {
@@ -50,7 +51,7 @@ export class DisciplineMapper {
         position: teacher.position as Position,
         rating: +teacher.rating,
         disciplineTeacherId: disciplineTeacher.id,
-        roles: disciplineTeacher.roles.map((r) => r.role),
+        roles: disciplineTeacher.roles.map((r) => TeacherRoleAdapter[r.disciplineType.name]),
         cathedras: teacher.cathedras.map(({ cathedra: { id, name, abbreviation, division } }) => ({
           id,
           name,
@@ -126,7 +127,7 @@ export class DisciplineMapper {
     });
   }
 
-  getSelectiveDisciplines (disciplines: DbDiscipline[], withAmount = false): 
+  getSelectiveDisciplines (disciplines: DbDiscipline[], withAmount = false):
     SelectiveDisciplinesWithAmountResponse[] | SelectiveDisciplinesResponse[] {
     const result = [];
     disciplines.forEach((discipline) => {

--- a/fictadvisor-api/src/v2/mappers/DisciplineTeacherMapper.ts
+++ b/fictadvisor-api/src/v2/mappers/DisciplineTeacherMapper.ts
@@ -3,6 +3,7 @@ import { DbDisciplineTeacher } from '../database/entities/DbDisciplineTeacher';
 import { Subject } from '@prisma/client';
 import { DisciplineTeacherFullResponse, SubjectResponse } from '@fictadvisor/utils/responses';
 import { TeacherRole, AcademicStatus, ScientificDegree, Position } from '@fictadvisor/utils/enums';
+import {TeacherRoleAdapter} from "./TeacherRoleAdapter";
 
 @Injectable()
 export class DisciplineTeacherMapper {
@@ -17,7 +18,7 @@ export class DisciplineTeacherMapper {
     return {
       disciplineTeacherId: disciplineTeacher.id,
       ...disciplineTeacher.teacher,
-      roles: disciplineTeacher.roles.map((r) => (r.role)),
+      roles: disciplineTeacher.roles.map((r) => (TeacherRoleAdapter[r.disciplineType.name])),
       rating: disciplineTeacher.teacher.rating.toNumber(),
     };
   }
@@ -29,7 +30,7 @@ export class DisciplineTeacherMapper {
   getRoles (disciplineTeachers: DbDisciplineTeacher[]): TeacherRole[] {
     const roles = new Set<TeacherRole>();
     for (const dt of disciplineTeachers) {
-      dt.roles.forEach((r) => roles.add(r.role));
+      dt.roles.forEach((r) => roles.add(TeacherRoleAdapter[r.disciplineType.name]));
     }
 
     return Array.from(roles);
@@ -39,7 +40,7 @@ export class DisciplineTeacherMapper {
     const roles = new Set<TeacherRole>();
     for (const dt of disciplineTeachers) {
       if (dt.discipline.subjectId === subjectId) {
-        dt.roles.forEach((r) => roles.add(r.role));
+        dt.roles.forEach((r) => roles.add(TeacherRoleAdapter[r.disciplineType.name]));
       }
     }
 
@@ -62,7 +63,7 @@ export class DisciplineTeacherMapper {
         position: teacher.position as Position,
         rating: +teacher.rating,
         disciplineTeacherId: disciplineTeacher.id,
-        roles: disciplineTeacher.roles.map((r) => r.role),
+        roles: disciplineTeacher.roles.map((r) => TeacherRoleAdapter[r.disciplineType.name]),
         subject: this.getSubject(subject),
         cathedras: teacher.cathedras.map(({ cathedra: { id, name, abbreviation, division } }) => ({
           id,

--- a/fictadvisor-api/src/v2/mappers/ScheduleMapper.ts
+++ b/fictadvisor-api/src/v2/mappers/ScheduleMapper.ts
@@ -10,7 +10,6 @@ import { some } from '../utils/ArrayUtil';
 import { DbEvent } from '../database/entities/DbEvent';
 import { DbDiscipline } from '../database/entities/DbDiscipline';
 import { DbDisciplineType } from '../database/entities/DbDisciplineType';
-import { TeacherRoleAdapter } from './TeacherRoleAdapter';
 
 @Injectable()
 export class ScheduleMapper {
@@ -49,7 +48,7 @@ export class ScheduleMapper {
       eventInfo: event.eventInfo[0]?.description || null,
       disciplineInfo: discipline?.description || null,
       teachers: discipline?.disciplineTeachers
-        .filter(({ roles }) => some(roles, 'role', TeacherRoleAdapter[disciplineType]))
+        .filter(({ roles }) => some(roles.map((role) => role.disciplineType), 'name', disciplineType))
         .map(({ teacher }) => ({
           id: teacher.id,
           firstName: teacher.firstName,

--- a/fictadvisor-api/src/v2/mappers/TeacherMapper.ts
+++ b/fictadvisor-api/src/v2/mappers/TeacherMapper.ts
@@ -9,6 +9,7 @@ import {
   Position,
 } from '@fictadvisor/utils/enums';
 import { DbTeacher } from '../database/entities/DbTeacher';
+import { TeacherRoleAdapter } from './TeacherRoleAdapter';
 
 @Injectable()
 export class TeacherMapper {
@@ -36,7 +37,7 @@ export class TeacherMapper {
   getRoles (teacher: DbTeacher): TeacherRole[] {
     const roles: TeacherRole[] = [];
     for (const dt of teacher.disciplineTeachers) {
-      roles.push(...dt.roles.map(({ role }) => role));
+      roles.push(...dt.roles.map(({ disciplineType }) => TeacherRoleAdapter[disciplineType.name]));
     }
 
     return [...new Set(roles)];

--- a/fictadvisor-api/src/v2/mappers/TeacherRoleAdapter.ts
+++ b/fictadvisor-api/src/v2/mappers/TeacherRoleAdapter.ts
@@ -1,4 +1,5 @@
-import { DisciplineTypeEnum, TeacherRole } from '@prisma/client';
+import { DisciplineTypeEnum } from '@prisma/client';
+import { TeacherRole } from '@fictadvisor/utils';
 
 export const TeacherRoleAdapter: {[key in keyof typeof DisciplineTypeEnum]?: TeacherRole | never} = {
   [DisciplineTypeEnum.LECTURE]: TeacherRole.LECTURER,

--- a/fictadvisor-api/src/v2/utils/parser/CampusParser.ts
+++ b/fictadvisor-api/src/v2/utils/parser/CampusParser.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { Parser } from './Parser';
 import axios from 'axios';
-import { DisciplineTypeEnum, TeacherRole } from '@prisma/client';
+import { DisciplineTypeEnum } from '@prisma/client';
 import { ScheduleDayType, ScheduleGroupType, SchedulePairType, ScheduleType } from './ScheduleParserTypes';
 import { DateService, StudyingSemester } from '../date/DateService';
 import { DbSubject } from '../../database/entities/DbSubject';
@@ -13,6 +13,8 @@ import { DisciplineTeacherRepository } from '../../database/repositories/Discipl
 import { SubjectRepository } from '../../database/repositories/SubjectRepository';
 import { GroupRepository } from '../../database/repositories/GroupRepository';
 import { GeneralParser } from './GeneralParser';
+import { TeacherRole } from '@fictadvisor/utils';
+import { TeacherRoleAdapter } from '../../mappers/TeacherRoleAdapter';
 
 export const DAY_NUMBER = {
   'Пн': 1,
@@ -178,16 +180,14 @@ export class CampusParser implements Parser {
         disciplineId: discipline.id,
         roles: {
           create: {
-            role,
             disciplineTypeId: disciplineType.id,
           },
         },
       });
-    } else if (!disciplineTeacher.roles.some((r) => r.role === role)) {
+    } else if (!disciplineTeacher.roles.some((r) => r.disciplineType.name === TeacherRoleAdapter[role])) {
       await this.disciplineTeacherRepository.updateById(disciplineTeacher.id, {
         roles: {
           create: {
-            role,
             disciplineTypeId: disciplineType.id,
           },
         },

--- a/fictadvisor-api/src/v2/utils/parser/RozParser.ts
+++ b/fictadvisor-api/src/v2/utils/parser/RozParser.ts
@@ -2,7 +2,7 @@ import axios from 'axios';
 import { JSDOM } from 'jsdom';
 import { Injectable } from '@nestjs/common';
 import { Parser } from './Parser';
-import { DisciplineTypeEnum, TeacherRole } from '@prisma/client';
+import { DisciplineTypeEnum } from '@prisma/client';
 import { DisciplineTeacherRepository } from '../../database/repositories/DisciplineTeacherRepository';
 import { DisciplineTeacherRoleRepository } from '../../database/repositories/DisciplineTeacherRoleRepository';
 import { GroupRepository } from '../../database/repositories/GroupRepository';
@@ -25,6 +25,7 @@ import { ExtendedSchedulePair } from './ScheduleParserTypes';
 import { DbDiscipline } from '../../database/entities/DbDiscipline';
 import { DbDisciplineType } from '../../database/entities/DbDisciplineType';
 import { GeneralParser } from './GeneralParser';
+import { TeacherRole } from '@fictadvisor/utils';
 
 const DISCIPLINE_TYPE = {
   Лек: DisciplineTypeEnum.LECTURE,


### PR DESCRIPTION
- created migration to transform type of role column in question_roles table to DisciplineTypeEnum
- deleted role column in discipline_teacher_roles table

closes #408
