### PR TITLE
bug #557: fixed dropdown menu

### DIFF
--- a/fictadvisor-web/src/app/(main)/schedule/schedule-page/schedule-event-edit-section/schedule-form/components/schedule-dropdown/ScheduleDropdown.styles.ts
+++ b/fictadvisor-web/src/app/(main)/schedule/schedule-page/schedule-event-edit-section/schedule-form/components/schedule-dropdown/ScheduleDropdown.styles.ts
@@ -76,7 +76,7 @@ export const dropdown: SxProps<Theme> = {
       },
     },
     '& .MuiAutocomplete-listbox': {
-      minHeight: 'min-content',
+      minHeight: '1rem',
       maxHeight: '160px',
       color: 'backgroundDark.200',
       borderRadius: '8px',

--- a/fictadvisor-web/src/components/common/ui/form/dropdown/Dropdown.styles.ts
+++ b/fictadvisor-web/src/components/common/ui/form/dropdown/Dropdown.styles.ts
@@ -107,7 +107,7 @@ export const dropdown: SxProps<Theme> = {
       },
     },
     '& .MuiAutocomplete-listbox': {
-      minHeight: 'min-content',
+      minHeight: '1rem',
       maxHeight: '160px',
       color: 'grey.600',
       borderRadius: '8px',


### PR DESCRIPTION
- the early dropdown menu had a minimal height equal to the number of items to render. Now, if the dropdown has four or fewer items, its height will depend on the item count. If there are more than four items, it will include a scroll area and have a height equivalent to four items.

closes #557 
