### PR TITLE
bug #583: fixed width for teacher header card

### DIFF
--- a/fictadvisor-web/src/components/common/ui/cards/teacher-header-card/TeacherHeaderCard.styles.ts
+++ b/fictadvisor-web/src/components/common/ui/cards/teacher-header-card/TeacherHeaderCard.styles.ts
@@ -38,6 +38,7 @@ export const description: SxProps<Theme> = {
     mobile: '14px',
     desktop: '11px',
   },
+  maxWidth: '272px',
   textTransform: 'none',
   overflow: 'hidden',
   WebkitBoxOrient: 'vertical',


### PR DESCRIPTION
- The problem was fixed by adding a maxWidth value. Due to the varying sizes of elements on the Figma UI board, I manually calculated the width for the teacher card to be 272px. Now, cards with lengthy discipline names will have the same width as those with short discipline names.

closes #583 
