### PR TITLE
bug: fixed error of campus parser

### DIFF
--- a/fictadvisor-api/src/v2/utils/parser/CampusParser.ts
+++ b/fictadvisor-api/src/v2/utils/parser/CampusParser.ts
@@ -21,7 +21,7 @@ import {
 export class CampusParser implements Parser<CampusParserGroup> {
   constructor (private dateService: DateService) {}
 
-  async parseGroups (groupNames: string[]): Promise<CampusParserGroup[]> {
+  async parseGroups (groupNames: string[] = []): Promise<CampusParserGroup[]> {
     const { data } = await axios.get(
       'https://api.campus.kpi.ua/schedule/groups'
     );


### PR DESCRIPTION
- added default value for `parseGroups` parameter of campus parser to avoid exception while reading `.length` of group names array
